### PR TITLE
[Refactor] jti 도입 및 인증 로직 전체 리팩토링

### DIFF
--- a/prisma/migrations/20250926173616_add_jti_to_refreshtoken/migration.sql
+++ b/prisma/migrations/20250926173616_add_jti_to_refreshtoken/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[jti]` on the table `RefreshToken` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."RefreshToken" ADD COLUMN     "jti" TEXT NOT NULL DEFAULT gen_random_uuid();
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_jti_key" ON "public"."RefreshToken"("jti");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,7 +4,6 @@
 // Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
-
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
@@ -13,7 +12,6 @@ datasource db {
 generator client {
   provider = "prisma-client-js"
 }
-
 
 model User {
   id String @id @default(uuid())
@@ -44,8 +42,10 @@ model User {
   refreshTokens RefreshToken[]
   @@unique([provider, providerId])
 }
+
 model RefreshToken {
   id        String   @id @default(uuid())
+  jti       String   @unique @default(dbgenerated("gen_random_uuid()"))
   tokenHash String   @unique
   userId    String
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -55,6 +55,7 @@ model RefreshToken {
 
   @@index([userId, expiresAt])
 }
+
 enum Role {
   DRIVER
   CONSUMER
@@ -146,7 +147,6 @@ model ConsumerProfile {
   chattingRooms ChattingRoom[]
 }
 
-
 model Request {
   id String @id @default(uuid())
   consumerId String 
@@ -209,7 +209,6 @@ model ChattingMessage {
   updatedAt DateTime @updatedAt
   senderId String
   sender User @relation(fields: [senderId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-
   isRead Boolean @default(false)
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,8 @@ import { HttpConfig } from './shared/config/http.config';
 import { ConfigNotFoundException } from './shared/exceptions/config-not-found.exception';
 import { CustomExceptionFilter } from './shared/middlewares/http-exception.filter';
 import { SuccessInterceptor } from './shared/interceptors/success.interceptor';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'; // 👈 Swagger import
-import { patchNestjsSwagger } from '@anatine/zod-nestjs'; // 👈 Zod를 위한 패치 import
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { patchNestjsSwagger } from '@anatine/zod-nestjs';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -57,14 +57,19 @@ export class AuthController {
   async signOut(@AuthUser() user: AccessTokenPayload, @Res({ passthrough: true }) res: Response) {
     await this.authService.signOut(user);
 
-    const cookieOptions = {
+    res.clearCookie('__Host-access_token', {
       httpOnly: true,
-      secure: true,
+      secure: process.env.NODE_ENV === 'production',
       path: '/',
-      sameSite: 'lax' as const,
-    };
-    res.clearCookie('__Host-access_token', cookieOptions);
-    res.clearCookie('__Host-refresh_token', cookieOptions);
+      sameSite: 'lax',
+    });
+
+    res.clearCookie('__Host-rt', {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      path: '/api/auth/refresh',
+      sameSite: 'strict',
+    });
 
     return { message: 'Successfully signed out' };
   }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -7,7 +7,7 @@ import { SignUpRequestDto, signUpSchema } from './dto/signup.request.dto';
 import { AUTH_SERVICE, type IAuthService } from './interface/auth.service.interface';
 import { AuthGuard } from './guards/auth.guard';
 import { AuthUser } from './decorators/auth-user.decorator';
-import { type AccessTokenPayload } from '@/shared/jwt/jwt.service.interface';
+import { type AccessTokenPayload } from '@/shared/jwt/jwt.payload.schema';
 
 @ApiTags('인증 (Auth)')
 @Controller('auth')

--- a/src/modules/auth/decorators/auth-user.decorator.ts
+++ b/src/modules/auth/decorators/auth-user.decorator.ts
@@ -1,5 +1,5 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
-import { AccessTokenPayload } from '@/shared/jwt/jwt.service.interface';
+import { AccessTokenPayload } from '@/shared/jwt/jwt.payload.schema';
 import { Request } from 'express';
 
 // createParamDecorator를 사용해 @AuthUser() 데코레이터를 만듭니다.

--- a/src/modules/auth/guards/auth.guard.ts
+++ b/src/modules/auth/guards/auth.guard.ts
@@ -1,5 +1,5 @@
 import { UnauthorizedException } from '@/shared/exceptions/unauthorized.exception';
-import { AccessTokenPayload } from '@/shared/jwt/jwt.service.interface';
+import { AccessTokenPayload } from '@/shared/jwt/jwt.payload.schema';
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';

--- a/src/modules/auth/infra/prisma-token.repository.ts
+++ b/src/modules/auth/infra/prisma-token.repository.ts
@@ -1,16 +1,17 @@
-import { ITokenRepository, RefreshTokenEntity } from '../interface/token.repository.interface';
 import { PrismaService } from '@/shared/prisma/prisma.service';
 import { Injectable } from '@nestjs/common';
+import { ITokenRepository, RefreshTokenEntity } from '../interface/token.repository.interface';
 
 @Injectable()
 export class PrismaTokenRepository implements ITokenRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async saveRefreshToken(userId: string, tokenHash: string, expiresAt: Date): Promise<RefreshTokenEntity> {
+  async saveRefreshToken(userId: string, tokenHash: string, jti: string, expiresAt: Date): Promise<RefreshTokenEntity> {
     return await this.prisma.refreshToken.create({
       data: {
         userId,
         tokenHash,
+        jti,
         expiresAt,
       },
     });
@@ -34,9 +35,9 @@ export class PrismaTokenRepository implements ITokenRepository {
     return;
   }
 
-  async deleteTokensByUserId(userId: string): Promise<void> {
-    await this.prisma.refreshToken.deleteMany({
-      where: { userId },
+  async deleteTokenByJti(jti: string): Promise<void> {
+    await this.prisma.refreshToken.delete({
+      where: { jti },
     });
     return;
   }

--- a/src/modules/auth/interface/auth.service.interface.ts
+++ b/src/modules/auth/interface/auth.service.interface.ts
@@ -1,7 +1,7 @@
-import { AccessTokenPayload } from '@/shared/jwt/jwt.service.interface';
+import { SignInResponseDto, SignUpResponseDto } from '@/modules/users/dto/user.response.dto';
+import { AccessTokenPayload } from '@/shared/jwt/jwt.payload.schema';
 import { SignInRequest } from '../dto/signIn.request.dto';
 import { SignUpRequest } from '../dto/signup.request.dto';
-import { SignInResponseDto, SignUpResponseDto } from '@/modules/users/dto/user.response.dto';
 
 export interface SignInResponse {
   accessToken: string;

--- a/src/modules/auth/interface/token.repository.interface.ts
+++ b/src/modules/auth/interface/token.repository.interface.ts
@@ -1,5 +1,6 @@
 export interface RefreshTokenEntity {
   id: string;
+  jti: string;
   tokenHash: string;
   userId: string;
   expiresAt: Date;
@@ -8,13 +9,13 @@ export interface RefreshTokenEntity {
 }
 
 export interface ITokenRepository {
-  saveRefreshToken(userId: string, tokenHash: string, expiresAt: Date): Promise<RefreshTokenEntity>;
+  saveRefreshToken(userId: string, tokenHash: string, jti: string, expiresAt: Date): Promise<RefreshTokenEntity>;
 
   findTokenByHash(tokenHash: string): Promise<RefreshTokenEntity | null>;
 
   markTokenAsUsed(tokenId: string): Promise<void>;
 
-  deleteTokensByUserId(userId: string): Promise<void>;
+  deleteTokenByJti(jti: string): Promise<void>;
 }
 
 export const TOKEN_REPOSITORY = 'ITokenRepository';

--- a/src/shared/config/http.config.ts
+++ b/src/shared/config/http.config.ts
@@ -3,7 +3,7 @@ import { parseOriginsSafe } from '@shared/utils/cors';
 
 export default registerAs('http', () => ({
   corsOrigins: parseOriginsSafe(process.env.NEXT_URL, process.env.NEXT_PREVIEW_URL, process.env.EXTRA_ORIGINS),
-  port: Number(process.env.PORT ?? 3000),
+  port: Number(process.env.PORT ?? 4000),
 }));
 
 export type HttpConfig = {

--- a/src/shared/jwt/jwt.payload.schema.ts
+++ b/src/shared/jwt/jwt.payload.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { Role } from '@prisma/client';
+
+export const jwtPayloadSchema = z.object({
+  sub: z.string(),
+  jti: z.string().uuid(),
+});
+
+export const accessTokenPayloadSchema = jwtPayloadSchema.extend({
+  role: z.nativeEnum(Role),
+});
+
+export type JwtPayload = z.infer<typeof jwtPayloadSchema>;
+export type AccessTokenPayload = z.infer<typeof accessTokenPayloadSchema>;

--- a/src/shared/jwt/jwt.service.interface.ts
+++ b/src/shared/jwt/jwt.service.interface.ts
@@ -1,18 +1,10 @@
-import { Role } from '@prisma/client';
-
-export interface JwtPayload {
-  sub: string;
-}
-
-export interface AccessTokenPayload extends JwtPayload {
-  jti: string;
-  role: Role;
-}
+import { AccessTokenPayload, JwtPayload } from './jwt.payload.schema';
 
 export interface IJwtService {
   signAccessToken(payload: AccessTokenPayload): Promise<string>;
   signRefreshToken(payload: JwtPayload): Promise<string>;
-  verifyAsync<T extends JwtPayload = JwtPayload>(token: string): Promise<T>;
+  verifyAccessToken<T extends AccessTokenPayload = AccessTokenPayload>(token: string): Promise<T>;
+  verifyRefreshToken<T extends JwtPayload = JwtPayload>(token: string): Promise<T>;
 }
 
 export const JWT_SERVICE = 'IJwtService';

--- a/src/shared/jwt/nestjs-jwt.service.ts
+++ b/src/shared/jwt/nestjs-jwt.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
-import { AccessTokenPayload, IJwtService, JwtPayload } from '@/shared/jwt/jwt.service.interface';
+import { IJwtService } from '@/shared/jwt/jwt.service.interface';
+import { AccessTokenPayload, JwtPayload } from './jwt.payload.schema';
 
 @Injectable()
 export class NestjsJwtService implements IJwtService {
@@ -23,9 +24,15 @@ export class NestjsJwtService implements IJwtService {
     });
   }
 
-  async verifyAsync<T extends JwtPayload = JwtPayload>(token: string): Promise<T> {
+  async verifyAccessToken<T extends AccessTokenPayload = AccessTokenPayload>(token: string): Promise<T> {
     return this.jwtService.verifyAsync<T>(token, {
       secret: this.configService.get<string>('JWT_ACCESS_SECRET'),
+    });
+  }
+
+  async verifyRefreshToken<T extends JwtPayload = JwtPayload>(token: string): Promise<T> {
+    return this.jwtService.verifyAsync<T>(token, {
+      secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
     });
   }
 }

--- a/test/http-test/yujin.http
+++ b/test/http-test/yujin.http
@@ -115,7 +115,7 @@ Content-Type: application/json
 
 {
   "email": "login-test@test.com",
-  "password": "wrong-password",
+  "password": "password123",
   "role": "CONSUMER"
 }
 
@@ -158,12 +158,10 @@ Content-Type: application/json
 ### Auth APIs
 ### =================================================
 
-@baseUrl = http://localhost:3000
-
 ### -------------------------------------------------
 ### 1. 로그인 (먼저 실행하여 쿠키를 받아야 합니다)
 # @name signIn
-POST {{baseUrl}}/auth/signIn
+POST {{host}}/auth/signIn
 Content-Type: application/json
 
 {
@@ -176,10 +174,10 @@ Content-Type: application/json
 ### -------------------------------------------------
 ### 2. 로그아웃 성공 (로그인 후 실행)
 # @name signOutSuccess
-POST {{baseUrl}}/auth/signOut
-Cookie: __Host-access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5NDhhNjczOS1iOGRjLTRiYTMtYWUyYS0yOTQ4NDQzM2YzZTkiLCJqdGkiOiJmYWYwY2EwMS1mZjdhLTQ4MTUtOWNjNS1mZTBhY2VkZWM3YzQiLCJyb2xlIjoiQ09OU1VNRVIiLCJpYXQiOjE3NTg3ODc3MjAsImV4cCI6MTc1ODc4ODYyMH0.DRHGMa9GWyLW-yPhxv4SXEEmi0mqa1ZRJuFaxcjBiPs;
+POST {{host}}/auth/signOut
+Cookie: __Host-access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5ZTJlNGI3ZS0zYjJhLTQ1ODMtYmMxMS02Yzc4ZWMzMDgzMzYiLCJqdGkiOiI4Y2E2NmI0Zi00OWNjLTQ1YmItOGJlMS1hODUwNDBjNDJiNzciLCJyb2xlIjoiQ09OU1VNRVIiLCJpYXQiOjE3NTg5MTA4MTksImV4cCI6MTc1ODkxMTcxOX0.cUuzVJQwsXuJGFhEVfbuRuOUulzJfgnKG-X_y6haPzQ; Max-Age=900;
 
 ### -------------------------------------------------
 ### 3. 로그아웃 실패 (인증되지 않은 경우)
 # @name signOutFailure
-POST {{baseUrl}}/auth/signOut
+POST {{host}}/auth/signOut


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#20

## #️⃣ 작업 내용
인증(Auth) 모듈의 안정성과 명확성을 높이기 위해 JWT 토큰에 jti (JWT ID)를 도입하고 관련 로직을 전체적으로 리팩토링했습니다.
주요 변경 사항
- JWT 타입 정의 방식 변경 : 기존의 interface 기반 타입 대신, Zod 스키마와 z.infer를 사용하여 JWT 페이로드의 유효성 검증 규칙과 TypeScript 타입을 단일 소스로 통합했습니다.
- JwtPayload와 AccessTokenPayload 타입을 명확히 정의하고 적용했습니다.

signIn 로직 강화
- 로그인 시 Refresh Token에 고유한 jti (UUID)를 발급합니다.
- 발급된 Refresh Token의 정보를 DB에 저장하고, DB에 저장된 레코드의 jti를 Access Token의 jti로 사용하여 두 토큰을 명확하게 연결했습니다.

signOut 로직 수정
- 기존의 불분명했던 로직을 수정하여, Access Token의 jti를 이용해 연결된 Refresh Token 레코드 하나만 정확히 삭제하도록 변경했습니다. (단일 세션 로그아웃)

데이터베이스 스키마 업데이트
- RefreshToken 테이블에 jti 컬럼을 @unique로 추가했습니다.
- prisma migrate 과정에서 발생한 기존 데이터 문제를 @default(dbgenerated("gen_random_uuid()"))를 사용하여 해결했습니다.
- Controller 쿠키 처리 버그 수정 : signOut 시 Refresh Token 쿠키를 삭제할 때, path와 name이 일치하지 않아 삭제되지 않던 버그를 수정했습니다.

#️⃣ 테스트 결과
로컬 환경에서 VS Code의 REST Client 확장 프로그램(.http 파일)을 사용하여 API 테스트를 완료했습니다.
- 로그인: POST /auth/signin 요청 성공 후, 응답 헤더에 Set-Cookie로 __Host-access_token과 __Host-rt가 정상적으로 포함된 것을 확인했습니다.
- 로그아웃: 로그인 후 발급된 쿠키를 포함하여 POST /auth/signout 요청 시, 정상 응답(200 OK) 및 응답 헤더에 쿠키를 삭제하라는 Set-Cookie 지시가 포함된 것을 확인했습니다.

#️⃣ 변경 사항 체크리스트
- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요? (수동 API 테스트 완료)
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

#️⃣ 리뷰 요구사항 (선택)
AuthService의 signIn 메서드에서 Access Token과 Refresh Token을 jti로 연결하는 로직이 가장 핵심적인 변경 사항입니다. 
이 부분의 안정성과 효율성에 대해 집중적으로 리뷰해 주시면 감사하겠습니다.