### PR TITLE
[FIX] dev 환경에서 __Host-/__Secure- prefix로 인한 쿠키 미전송 문제 해결

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,23 +1,27 @@
+import type { AccessTokenPayload, JwtPayload } from '@/shared/jwt/jwt.payload.schema';
 import { ZodValidationPipe } from '@/shared/pipes/zod-validation.pipe';
+import { CookiesService } from '@/shared/utils/cookies.service';
 import { Body, Controller, HttpCode, HttpStatus, Inject, Post, Res, UseGuards, UsePipes } from '@nestjs/common';
-import { ApiOperation, ApiTags, ApiResponse } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import type { Response } from 'express';
-import { SignInRequestDto, signInSchema } from './dto/signIn.request.dto';
-import { SignUpRequestDto, signUpSchema } from './dto/signup.request.dto';
-import { AUTH_SERVICE, type IAuthService } from './interface/auth.service.interface';
-import { AccessTokenGuard } from './guards/accessToken.gaurd';
 import { AuthUser } from './decorators/auth-user.decorator';
-import type { JwtPayload, AccessTokenPayload } from '@/shared/jwt/jwt.payload.schema';
-import { RefreshTokenGuard } from './guards/refreshToken.guard';
 import { RefreshPayload } from './decorators/refresh-payload.decorator';
 import { RefreshRaw } from './decorators/refresh-raw.decorator';
+import { SignInRequestDto, signInSchema } from './dto/signIn.request.dto';
+import { SignUpRequestDto, signUpSchema } from './dto/signup.request.dto';
+import { AccessTokenGuard } from './guards/accessToken.gaurd';
+import { RefreshTokenGuard } from './guards/refreshToken.guard';
+import { AUTH_SERVICE, type IAuthService } from './interface/auth.service.interface';
 
 @ApiTags('인증 (Auth)')
 @Controller('auth')
 export class AuthController {
-  constructor(@Inject(AUTH_SERVICE) private readonly authService: IAuthService) {}
+  constructor(
+    @Inject(AUTH_SERVICE) private readonly authService: IAuthService,
+    private readonly cookiesService: CookiesService,
+  ) {}
 
-  @Post('signup')
+  @Post('signUp')
   @ApiOperation({ summary: '로컬 회원가입' })
   @ApiResponse({ status: 201, description: '회원가입 성공' })
   @UsePipes(new ZodValidationPipe(signUpSchema))
@@ -32,23 +36,7 @@ export class AuthController {
   @UsePipes(new ZodValidationPipe(signInSchema))
   async signIn(@Body() dto: SignInRequestDto, @Res({ passthrough: true }) res: Response) {
     const { accessToken, refreshToken, user } = await this.authService.signIn(dto);
-
-    res.cookie('__Host-access_token', accessToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      path: '/',
-      sameSite: 'lax',
-      maxAge: 15 * 60 * 1000,
-    });
-
-    res.cookie('__Host-rt', refreshToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      path: '/api/auth/refresh',
-      sameSite: 'strict',
-      maxAge: 7 * 24 * 60 * 60 * 1000,
-    });
-
+    this.cookiesService.setAuthCookies(res, accessToken, refreshToken);
     return user;
   }
 
@@ -59,21 +47,7 @@ export class AuthController {
   @UseGuards(AccessTokenGuard)
   async signOut(@AuthUser() user: AccessTokenPayload, @Res({ passthrough: true }) res: Response) {
     await this.authService.signOut(user);
-
-    res.clearCookie('__Host-access_token', {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      path: '/',
-      sameSite: 'lax',
-    });
-
-    res.clearCookie('__Host-rt', {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      path: '/api/auth/refresh',
-      sameSite: 'strict',
-    });
-
+    this.cookiesService.clearAuthCookies(res);
     return { message: 'Successfully signed out' };
   }
 
@@ -88,22 +62,7 @@ export class AuthController {
     @Res({ passthrough: true }) res: Response,
   ) {
     const { accessToken, refreshToken } = await this.authService.refreshToken(refresh, refreshRaw);
-
-    res.cookie('__Host-access_token', accessToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      path: '/',
-      sameSite: 'lax',
-      maxAge: 15 * 60 * 1000,
-    });
-
-    res.cookie('__Host-rt', refreshToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      path: '/api/auth/refresh',
-      sameSite: 'strict',
-      maxAge: 7 * 24 * 60 * 60 * 1000,
-    });
+    this.cookiesService.setAuthCookies(res, accessToken, refreshToken);
     return { message: '토큰 재발급 성공' };
   }
 }

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -10,9 +10,9 @@ import { RefreshTokenGuard } from './guards/refreshToken.guard';
 import { PrismaTokenRepository } from '@/modules/auth/infra/prisma-token.repository';
 import { AUTH_SERVICE } from './interface/auth.service.interface';
 import { TOKEN_REPOSITORY } from './interface/token.repository.interface';
-
+import { CookieModule } from '@/shared/utils/cookie.module';
 @Module({
-  imports: [UserModule, HashingModule, SharedJwtModule],
+  imports: [UserModule, HashingModule, SharedJwtModule, CookieModule],
   controllers: [AuthController],
   providers: [
     AccessTokenGuard,

--- a/src/shared/config/env.validation.ts
+++ b/src/shared/config/env.validation.ts
@@ -15,6 +15,7 @@ export const validationSchema = z.object({
       message: 'JWT_ACCESS_EXPIRES_IN must be a valid time string (e.g., "15m", "1h")',
     })
     .default('15m'),
+  JWT_ACCESS_MAX_AGE_MS: z.coerce.number().optional().default(900000),
   JWT_REFRESH_SECRET: z.string().min(1),
   JWT_REFRESH_EXPIRES_IN: z
     .string()
@@ -22,6 +23,12 @@ export const validationSchema = z.object({
       message: 'JWT_REFRESH_EXPIRES_IN must be a valid time string (e.g., "7d")',
     })
     .default('7d'),
+  JWT_REFRESH_MAX_AGE_MS: z.coerce.number().optional().default(604800000),
   JWT_ISSUER: z.string().url(),
+  ACCESS_SAMESITE: z.enum(['lax', 'strict', 'none']).optional(),
+  REFRESH_SAMESITE: z.enum(['lax', 'strict', 'none']).optional(),
+  ACCESS_COOKIE_PREFIX: z.string().optional(),
+  REFRESH_COOKIE_PREFIX: z.string().optional(),
+  REFRESH_COOKIE_DOMAIN: z.string().optional(),
   BCRYPT_SALT_ROUNDS: z.coerce.number().default(10),
 });

--- a/src/shared/utils/cookie.module.ts
+++ b/src/shared/utils/cookie.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { CookiesService } from './cookies.service';
+
+@Module({
+  providers: [CookiesService],
+  exports: [CookiesService],
+})
+export class CookieModule {}

--- a/src/shared/utils/cookies.service.ts
+++ b/src/shared/utils/cookies.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@nestjs/common';
+import type { CookieOptions, Response } from 'express';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class CookiesService {
+  constructor(private readonly config: ConfigService) {}
+
+  private get isProd() {
+    return this.config.get<string>('NODE_ENV') === 'production';
+  }
+
+  private get useSecure() {
+    return this.isProd;
+  }
+
+  private toNumber(v: unknown, fallback: number): number {
+    const n = typeof v === 'string' ? Number(v) : Number(v);
+    return Number.isFinite(n) ? n : fallback;
+  }
+
+  private pickSameSite(envVal: string | undefined, fallback: CookieOptions['sameSite']) {
+    const v = (envVal as CookieOptions['sameSite']) ?? fallback;
+
+    if (v === 'none' && !this.useSecure) return 'lax';
+    return v;
+  }
+
+  private get accessCookieName() {
+    const prefix = this.useSecure ? (this.config.get<string>('ACCESS_COOKIE_PREFIX') ?? '__Host-') : '';
+    return `${prefix}access_token`;
+  }
+
+  private get refreshCookieName() {
+    const prefix = this.useSecure ? (this.config.get<string>('REFRESH_COOKIE_PREFIX') ?? '__Secure-') : '';
+    return `${prefix}refresh_token`;
+  }
+
+  private buildAccessOpts(): CookieOptions {
+    const sameSite = this.pickSameSite(this.config.get<string>('ACCESS_SAMESITE'), this.isProd ? 'none' : 'lax');
+    const maxAge = this.toNumber(this.config.get('JWT_ACCESS_MAX_AGE_MS'), 900_000);
+    return {
+      httpOnly: true,
+      secure: this.useSecure,
+      path: '/',
+      sameSite,
+      maxAge,
+    };
+  }
+
+  private buildRefreshOpts(): CookieOptions {
+    const sameSite = this.pickSameSite(this.config.get<string>('REFRESH_SAMESITE'), this.isProd ? 'strict' : 'lax');
+    const maxAge = this.toNumber(this.config.get('JWT_REFRESH_MAX_AGE_MS'), 604_800_000);
+    const opts: CookieOptions = {
+      httpOnly: true,
+      secure: this.useSecure,
+      path: '/api/auth/refresh',
+      sameSite,
+      maxAge,
+    };
+
+    const domain = this.config.get<string>('REFRESH_DOMAIN');
+    if (domain && this.useSecure) opts.domain = domain;
+
+    return opts;
+  }
+
+  setAuthCookies(res: Response, accessToken: string, refreshToken: string) {
+    res.cookie(this.accessCookieName, accessToken, this.buildAccessOpts());
+    res.cookie(this.refreshCookieName, refreshToken, this.buildRefreshOpts());
+  }
+
+  clearAuthCookies(res: Response) {
+    res.clearCookie(this.accessCookieName, { ...this.buildAccessOpts(), maxAge: undefined });
+    res.clearCookie(this.refreshCookieName, { ...this.buildRefreshOpts(), maxAge: undefined });
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#28

## #️⃣ 작업 내용
1. 버그 발생 원인
로컬 개발 환경(http)에서는 __Host- 및 __Secure- 접두사를 가진 쿠키를 설정할 수 없는 브라우저 보안 정책으로 인해, 로그인 시 토큰 쿠키가 저장되지 않는 문제가 있었습니다.

2. 근본적인 문제 및 해결
이 버그를 해결하는 과정에서, 기존 쿠키 설정 로직이 컨트롤러에 흩어져 있고 환경별 설정이 정적으로 관리되어 유연성과 테스트 용이성이 떨어진다는 점을 발견했습니다.
이를 개선하기 위해 쿠키 관련 로직을 전담하는 CookiesService와 CookieModule을 도입하고 의존성 주입(DI)을 통해 사용하도록 전체 구조를 리팩토링했습니다. 이제 AuthController는 CookiesService에 쿠키 설정을 위임하며, NODE_ENV 값에 따라 동적으로 안전한 쿠키 옵션이 자동 설정됩니다.

## #️⃣ 변경 사항 체크리스트
- [x] CookiesService 및 CookieModule을 추가했나요?
- [x] AuthController에서 CookiesService를 주입받아 사용하도록 수정했나요?
- [x] 환경(NODE_ENV)에 따라 쿠키 옵션이 동적으로 변경되나요?
- [x] 기존 cookies.auth.ts 유틸리티 파일을 제거했나요?
- [x] Zod 유효성 검사 스키마에 쿠키 관련 ENV를 추가했나요?

## #️⃣ 테스트 결과
- 로컬 개발 환경에서 아래 절차에 따라 정상 동작을 확인할 수 있습니다.
- npm run start:dev로 백엔드 서버를 실행합니다.
- 프론트엔드(http://localhost:3000)에서 로그인/회원가입을 진행합니다.
- 브라우저 개발자 도구 Application → Cookies 탭에서 쿠키 이름이 접두사 없는 access_token과 refresh_token으로 생성되는지 확인합니다.
- 이후 API 요청 시 Network 탭에서 요청 헤더에 해당 쿠키가 자동으로 포함되어 인증이 통과되는지 확인합니다.
예상 결과: 위 절차를 통해 개발 환경에서 쿠키가 정상적으로 설정되고 API 인증이 통과되어야 합니다.

## #️⃣ 리뷰 요구사항 (선택)
- 새롭게 추가된 CookiesService의 책임과 역할이 명확하게 분리되었는지 확인 부탁드립니다.
- 개발 환경과 운영 환경의 쿠키 정책 차이(SameSite, Secure 등)가 적절한지 검토해주시면 감사하겠습니다.
