### PR TITLE
[Refactor] 전체 데이터베이스 스키마 리팩토링 및 개선

### DIFF
--- a/prisma/migrations/20251002080418_add_request_kind/migration.sql
+++ b/prisma/migrations/20251002080418_add_request_kind/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `requestKind` to the `Request` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "public"."RequestKind" AS ENUM ('GENERAL', 'DIRECT');
+
+-- AlterTable
+ALTER TABLE "public"."Request" ADD COLUMN     "requestKind" "public"."RequestKind" NOT NULL;

--- a/prisma/migrations/20251003193937_full_schema_refactor_v2/migration.sql
+++ b/prisma/migrations/20251003193937_full_schema_refactor_v2/migration.sql
@@ -1,0 +1,375 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `isRead` on the `ChattingMessage` table. All the data in the column will be lost.
+  - You are about to drop the column `consumerProfileId` on the `ChattingRoom` table. All the data in the column will be lost.
+  - You are about to drop the column `driverProfileId` on the `ChattingRoom` table. All the data in the column will be lost.
+  - You are about to drop the column `isRead` on the `Notification` table. All the data in the column will be lost.
+  - You are about to drop the column `arrivalArea` on the `Quotation` table. All the data in the column will be lost.
+  - You are about to drop the column `arrivalSize` on the `Quotation` table. All the data in the column will be lost.
+  - You are about to drop the column `consumerProfileId` on the `Quotation` table. All the data in the column will be lost.
+  - You are about to drop the column `departureArea` on the `Quotation` table. All the data in the column will be lost.
+  - You are about to drop the column `departureSize` on the `Quotation` table. All the data in the column will be lost.
+  - You are about to drop the column `driverProfileId` on the `Quotation` table. All the data in the column will be lost.
+  - You are about to drop the column `quotationStatement` on the `Quotation` table. All the data in the column will be lost.
+  - You are about to drop the column `requirements` on the `Quotation` table. All the data in the column will be lost.
+  - You are about to drop the column `arrivalSize` on the `Request` table. All the data in the column will be lost.
+  - You are about to drop the column `consumerProfileId` on the `Request` table. All the data in the column will be lost.
+  - You are about to drop the column `departureSize` on the `Request` table. All the data in the column will be lost.
+  - You are about to drop the column `requestKind` on the `Request` table. All the data in the column will be lost.
+  - You are about to drop the column `requestStatement` on the `Request` table. All the data in the column will be lost.
+  - You are about to drop the column `requirements` on the `Request` table. All the data in the column will be lost.
+  - You are about to drop the column `targetDriverId` on the `Request` table. All the data in the column will be lost.
+  - You are about to drop the column `consumerProfileId` on the `Review` table. All the data in the column will be lost.
+  - You are about to drop the column `driverProfileId` on the `Review` table. All the data in the column will be lost.
+  - You are about to drop the column `rate` on the `Review` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[requestId,driverId]` on the table `ChattingRoom` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[chattingMessageId]` on the table `Quotation` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[quotationId]` on the table `Review` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `arrivalElevator` to the `Quotation` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `arrivalPyeong` to the `Quotation` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `chattingMessageId` to the `Quotation` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `departureElevator` to the `Quotation` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `departurePyeong` to the `Quotation` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `moveAt` to the `Quotation` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `serviceType` to the `Quotation` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `arrivalElevator` to the `Request` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `arrivalPyeong` to the `Request` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `departureElevator` to the `Request` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `departurePyeong` to the `Request` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updatedAt` to the `Request` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `rating` to the `Review` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "public"."RequestStatus" AS ENUM ('PENDING', 'CONCLUDED', 'COMPLETE', 'EXPIRED', 'CANCELED', 'WITHDRAWN');
+
+-- CreateEnum
+CREATE TYPE "public"."ActionState" AS ENUM ('ACCEPTED', 'REJECTED');
+
+-- CreateEnum
+CREATE TYPE "public"."ActionSource" AS ENUM ('GENERAL', 'INVITED');
+
+-- CreateEnum
+CREATE TYPE "public"."QuotationStatus" AS ENUM ('SUBMITTED', 'REVISED', 'WITHDRAWN', 'SELECTED', 'EXPIRED');
+
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "public"."NotificationType" ADD VALUE 'INVITE_RECEIVED';
+ALTER TYPE "public"."NotificationType" ADD VALUE 'INVITE_CANCELLED';
+ALTER TYPE "public"."NotificationType" ADD VALUE 'REQUEST_CONCLUDED';
+ALTER TYPE "public"."NotificationType" ADD VALUE 'REQUEST_COMPLETED';
+ALTER TYPE "public"."NotificationType" ADD VALUE 'REQUEST_EXPIRED';
+ALTER TYPE "public"."NotificationType" ADD VALUE 'MOVE_DAY_REMINDER';
+
+-- DropForeignKey
+ALTER TABLE "public"."ChattingMessage" DROP CONSTRAINT "ChattingMessage_senderId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."ChattingRoom" DROP CONSTRAINT "ChattingRoom_consumerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."ChattingRoom" DROP CONSTRAINT "ChattingRoom_consumerProfileId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."ChattingRoom" DROP CONSTRAINT "ChattingRoom_driverId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."ChattingRoom" DROP CONSTRAINT "ChattingRoom_driverProfileId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."ChattingRoom" DROP CONSTRAINT "ChattingRoom_requestId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Quotation" DROP CONSTRAINT "Quotation_chattingRoomId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Quotation" DROP CONSTRAINT "Quotation_consumerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Quotation" DROP CONSTRAINT "Quotation_consumerProfileId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Quotation" DROP CONSTRAINT "Quotation_driverId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Quotation" DROP CONSTRAINT "Quotation_driverProfileId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Quotation" DROP CONSTRAINT "Quotation_requestId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Request" DROP CONSTRAINT "Request_consumerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Request" DROP CONSTRAINT "Request_consumerProfileId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Request" DROP CONSTRAINT "Request_targetDriverId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Review" DROP CONSTRAINT "Review_consumerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Review" DROP CONSTRAINT "Review_consumerProfileId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Review" DROP CONSTRAINT "Review_driverId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Review" DROP CONSTRAINT "Review_driverProfileId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Review" DROP CONSTRAINT "Review_quotationId_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."ChattingMessage" DROP COLUMN "isRead",
+ALTER COLUMN "content" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."ChattingRoom" DROP COLUMN "consumerProfileId",
+DROP COLUMN "driverProfileId",
+ADD COLUMN     "closedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "public"."Notification" DROP COLUMN "isRead",
+ADD COLUMN     "chattingRoomId" TEXT,
+ADD COLUMN     "quotationId" TEXT,
+ADD COLUMN     "readAt" TIMESTAMP(3),
+ADD COLUMN     "requestId" TEXT,
+ADD COLUMN     "reviewId" TEXT,
+ADD COLUMN     "senderId" TEXT;
+
+-- AlterTable
+ALTER TABLE "public"."Quotation" DROP COLUMN "arrivalArea",
+DROP COLUMN "arrivalSize",
+DROP COLUMN "consumerProfileId",
+DROP COLUMN "departureArea",
+DROP COLUMN "departureSize",
+DROP COLUMN "driverProfileId",
+DROP COLUMN "quotationStatement",
+DROP COLUMN "requirements",
+ADD COLUMN     "additionalRequirements" TEXT,
+ADD COLUMN     "arrivalElevator" BOOLEAN NOT NULL,
+ADD COLUMN     "arrivalPyeong" DOUBLE PRECISION NOT NULL,
+ADD COLUMN     "chattingMessageId" TEXT NOT NULL,
+ADD COLUMN     "departureElevator" BOOLEAN NOT NULL,
+ADD COLUMN     "departurePyeong" DOUBLE PRECISION NOT NULL,
+ADD COLUMN     "moveAt" DATE NOT NULL,
+ADD COLUMN     "previousQuotationId" TEXT,
+ADD COLUMN     "selectedAt" TIMESTAMP(3),
+ADD COLUMN     "serviceType" "public"."MoveType" NOT NULL,
+ADD COLUMN     "status" "public"."QuotationStatus" NOT NULL DEFAULT 'SUBMITTED',
+ADD COLUMN     "validUntil" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "public"."Request" DROP COLUMN "arrivalSize",
+DROP COLUMN "consumerProfileId",
+DROP COLUMN "departureSize",
+DROP COLUMN "requestKind",
+DROP COLUMN "requestStatement",
+DROP COLUMN "requirements",
+DROP COLUMN "targetDriverId",
+ADD COLUMN     "additionalRequirements" TEXT,
+ADD COLUMN     "arrivalElevator" BOOLEAN NOT NULL,
+ADD COLUMN     "arrivalPyeong" DOUBLE PRECISION NOT NULL,
+ADD COLUMN     "canceledAt" TIMESTAMP(3),
+ADD COLUMN     "completedAt" TIMESTAMP(3),
+ADD COLUMN     "concludedAt" TIMESTAMP(3),
+ADD COLUMN     "departureElevator" BOOLEAN NOT NULL,
+ADD COLUMN     "departurePyeong" DOUBLE PRECISION NOT NULL,
+ADD COLUMN     "expiredAt" TIMESTAMP(3),
+ADD COLUMN     "requestStatus" "public"."RequestStatus" NOT NULL DEFAULT 'PENDING',
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "withdrawnAt" TIMESTAMP(3),
+ALTER COLUMN "moveAt" SET DATA TYPE DATE;
+
+-- AlterTable
+ALTER TABLE "public"."Review" DROP COLUMN "consumerProfileId",
+DROP COLUMN "driverProfileId",
+DROP COLUMN "rate",
+ADD COLUMN     "rating" INTEGER NOT NULL;
+
+-- DropEnum
+DROP TYPE "public"."QuotationStatement";
+
+-- DropEnum
+DROP TYPE "public"."RequestKind";
+
+-- DropEnum
+DROP TYPE "public"."RequestStatement";
+
+-- CreateTable
+CREATE TABLE "public"."Invite" (
+    "id" TEXT NOT NULL,
+    "requestId" TEXT NOT NULL,
+    "driverId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "canceledAt" TIMESTAMP(3),
+
+    CONSTRAINT "Invite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."DriverRequestAction" (
+    "id" TEXT NOT NULL,
+    "requestId" TEXT NOT NULL,
+    "driverId" TEXT NOT NULL,
+    "state" "public"."ActionState" NOT NULL,
+    "source" "public"."ActionSource" NOT NULL,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DriverRequestAction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ChatMessageRead" (
+    "messageId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "readAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ChatMessageRead_pkey" PRIMARY KEY ("messageId","userId")
+);
+
+-- CreateIndex
+CREATE INDEX "Invite_driverId_idx" ON "public"."Invite"("driverId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Invite_requestId_driverId_key" ON "public"."Invite"("requestId", "driverId");
+
+-- CreateIndex
+CREATE INDEX "DriverRequestAction_driverId_state_idx" ON "public"."DriverRequestAction"("driverId", "state");
+
+-- CreateIndex
+CREATE INDEX "DriverRequestAction_requestId_state_idx" ON "public"."DriverRequestAction"("requestId", "state");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DriverRequestAction_requestId_driverId_key" ON "public"."DriverRequestAction"("requestId", "driverId");
+
+-- CreateIndex
+CREATE INDEX "ChatMessageRead_userId_readAt_idx" ON "public"."ChatMessageRead"("userId", "readAt");
+
+-- CreateIndex
+CREATE INDEX "ChattingMessage_chattingRoomId_createdAt_idx" ON "public"."ChattingMessage"("chattingRoomId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ChattingRoom_consumerId_createdAt_idx" ON "public"."ChattingRoom"("consumerId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ChattingRoom_driverId_createdAt_idx" ON "public"."ChattingRoom"("driverId", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChattingRoom_requestId_driverId_key" ON "public"."ChattingRoom"("requestId", "driverId");
+
+-- CreateIndex
+CREATE INDEX "Notification_receiverId_readAt_idx" ON "public"."Notification"("receiverId", "readAt");
+
+-- CreateIndex
+CREATE INDEX "Notification_receiverId_createdAt_idx" ON "public"."Notification"("receiverId", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Quotation_chattingMessageId_key" ON "public"."Quotation"("chattingMessageId");
+
+-- CreateIndex
+CREATE INDEX "Quotation_driverId_createdAt_idx" ON "public"."Quotation"("driverId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Quotation_consumerId_createdAt_idx" ON "public"."Quotation"("consumerId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Quotation_requestId_createdAt_idx" ON "public"."Quotation"("requestId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Quotation_chattingRoomId_createdAt_idx" ON "public"."Quotation"("chattingRoomId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Request_departureArea_idx" ON "public"."Request"("departureArea");
+
+-- CreateIndex
+CREATE INDEX "Request_arrivalArea_idx" ON "public"."Request"("arrivalArea");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Review_quotationId_key" ON "public"."Review"("quotationId");
+
+-- AddForeignKey
+ALTER TABLE "public"."Request" ADD CONSTRAINT "Request_consumerId_fkey" FOREIGN KEY ("consumerId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Invite" ADD CONSTRAINT "Invite_requestId_fkey" FOREIGN KEY ("requestId") REFERENCES "public"."Request"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Invite" ADD CONSTRAINT "Invite_driverId_fkey" FOREIGN KEY ("driverId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."DriverRequestAction" ADD CONSTRAINT "DriverRequestAction_requestId_fkey" FOREIGN KEY ("requestId") REFERENCES "public"."Request"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."DriverRequestAction" ADD CONSTRAINT "DriverRequestAction_driverId_fkey" FOREIGN KEY ("driverId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChattingRoom" ADD CONSTRAINT "ChattingRoom_consumerId_fkey" FOREIGN KEY ("consumerId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChattingRoom" ADD CONSTRAINT "ChattingRoom_driverId_fkey" FOREIGN KEY ("driverId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChattingRoom" ADD CONSTRAINT "ChattingRoom_requestId_fkey" FOREIGN KEY ("requestId") REFERENCES "public"."Request"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChattingMessage" ADD CONSTRAINT "ChattingMessage_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChatMessageRead" ADD CONSTRAINT "ChatMessageRead_messageId_fkey" FOREIGN KEY ("messageId") REFERENCES "public"."ChattingMessage"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChatMessageRead" ADD CONSTRAINT "ChatMessageRead_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Quotation" ADD CONSTRAINT "Quotation_consumerId_fkey" FOREIGN KEY ("consumerId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Quotation" ADD CONSTRAINT "Quotation_driverId_fkey" FOREIGN KEY ("driverId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Quotation" ADD CONSTRAINT "Quotation_chattingRoomId_fkey" FOREIGN KEY ("chattingRoomId") REFERENCES "public"."ChattingRoom"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Quotation" ADD CONSTRAINT "Quotation_requestId_fkey" FOREIGN KEY ("requestId") REFERENCES "public"."Request"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Quotation" ADD CONSTRAINT "Quotation_previousQuotationId_fkey" FOREIGN KEY ("previousQuotationId") REFERENCES "public"."Quotation"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Quotation" ADD CONSTRAINT "Quotation_chattingMessageId_fkey" FOREIGN KEY ("chattingMessageId") REFERENCES "public"."ChattingMessage"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Review" ADD CONSTRAINT "Review_consumerId_fkey" FOREIGN KEY ("consumerId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Review" ADD CONSTRAINT "Review_driverId_fkey" FOREIGN KEY ("driverId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Review" ADD CONSTRAINT "Review_quotationId_fkey" FOREIGN KEY ("quotationId") REFERENCES "public"."Quotation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Notification" ADD CONSTRAINT "Notification_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Notification" ADD CONSTRAINT "Notification_requestId_fkey" FOREIGN KEY ("requestId") REFERENCES "public"."Request"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Notification" ADD CONSTRAINT "Notification_quotationId_fkey" FOREIGN KEY ("quotationId") REFERENCES "public"."Quotation"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Notification" ADD CONSTRAINT "Notification_chattingRoomId_fkey" FOREIGN KEY ("chattingRoomId") REFERENCES "public"."ChattingRoom"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Notification" ADD CONSTRAINT "Notification_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "public"."Review"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20251004093821_add_quote_limit_fields_to_request/migration.sql
+++ b/prisma/migrations/20251004093821_add_quote_limit_fields_to_request/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "public"."Request" ADD COLUMN     "generalQuoteCount" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "generalQuoteLimit" INTEGER NOT NULL DEFAULT 5,
+ADD COLUMN     "invitedQuoteCount" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "invitedQuoteLimit" INTEGER NOT NULL DEFAULT 3;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,7 +30,6 @@ model User {
   consumerLikes            LIKE[]            @relation("ConsumerLikesDriver") // 내가 소비자(consumer)로서 누군가(기사)를 좋아요한 기록들
   likedByConsumers         LIKE[]            @relation("DriverLikedByConsumer") // 내가 기사(driver)로서 소비자에게 받은 좋아요들
   requestsAsConsumer       Request[]         @relation("RequestsByConsumer")
-  requestsTargetedAsDriver Request[]         @relation("RequestsTargetingDriver")
   reviewsWritten           Review[]          @relation("ReviewsByConsumer")
   reviewsReceived          Review[]          @relation("ReviewsForDriver")
   quotationsAsConsumer     Quotation[]       @relation("QuotationsByConsumer")
@@ -38,9 +37,12 @@ model User {
   chatRoomsAsConsumer      ChattingRoom[]    @relation("RoomsByConsumer")
   chatRoomsAsDriver        ChattingRoom[]    @relation("RoomsByDriver")
   chattingMessages         ChattingMessage[]
-  notifications            Notification[]
+  receivedNotifications    Notification[]    @relation("ReceivedNotifications")
+  sentNotifications        Notification[]    @relation("SentNotifications")
   refreshTokens            RefreshToken[]
-
+  invitesAsDriver          Invite[]
+  driverRequestActions     DriverRequestAction[]
+  chatMessageReads         ChatMessageRead[]
   @@unique([provider, providerId])
 }
 
@@ -79,9 +81,6 @@ model DriverProfile {
   deletedAt          DateTime?
   driverServiceAreas DriverServiceArea[]
   driverServiceTypes DriverServiceType[]
-  reviewsReceived    Review[]            @relation("ReviewsForDriverProfile")
-  quotations         Quotation[]
-  chattingRooms      ChattingRoom[]
 }
 
 model DriverServiceArea {
@@ -103,7 +102,6 @@ model LIKE {
   consumer   User   @relation("ConsumerLikesDriver", fields: [consumerId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   driverId   String
   driver     User   @relation("DriverLikedByConsumer", fields: [driverId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-
   @@id([consumerId, driverId])
 }
 
@@ -133,6 +131,8 @@ enum Area {
   JEJU
 }
 
+// @Todo: consumerProfile의 지역은 하나의 지역만 설정이 가능하다.
+// 그러므로 areas를 area로 수정하는 작업이 필요
 model ConsumerProfile {
   id              String         @id @default(uuid())
   consumerId      String         @unique
@@ -143,147 +143,225 @@ model ConsumerProfile {
   createdAt       DateTime       @default(now())
   updatedAt       DateTime       @updatedAt
   deletedAt       DateTime?
-  consumerRequest Request[]
-  reviewsWritten  Review[]       @relation("ReviewsFromConsumerProfile")
-  quotations      Quotation[]
-  chattingRooms   ChattingRoom[]
 }
 
-model Request {
-  id                String           @id @default(uuid())
-  consumerId        String
-  consumer          User             @relation("RequestsByConsumer", fields: [consumerId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  consumerProfileId String
-  consumerProfile   ConsumerProfile  @relation(fields: [consumerProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  serviceType       MoveType
-  moveAt            DateTime
-  departureAddress  String
-  departureFloor    Int
-  departureSize     Float
-  arrivalAddress    String
-  arrivalFloor      Int
-  arrivalSize       Float
-  requirements      String?
-  departureArea     Area
-  arrivalArea       Area
-  requestStatement  RequestStatement
-  targetDriverId    String?
-  targetDriver      User?            @relation("RequestsTargetingDriver", fields: [targetDriverId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  createdAt         DateTime         @default(now())
-  deletedAt         DateTime?
-  chattingRooms     ChattingRoom[]
-  quotations        Quotation[]
+model Request { 
+  id                     String   @id @default(uuid()) 
+  consumerId             String
+  consumer               User    @relation("RequestsByConsumer", fields: [consumerId], references: [id], onUpdate: Cascade, onDelete: Restrict) 
+  serviceType            MoveType 
+  moveAt                 DateTime @db.Date
+  departureAddress       String 
+  departureFloor         Int 
+  departurePyeong        Float
+  departureElevator      Boolean 
+  arrivalAddress         String 
+  arrivalFloor           Int 
+  arrivalPyeong          Float
+  arrivalElevator        Boolean
+  additionalRequirements String? 
+  departureArea          Area 
+  arrivalArea            Area 
+  requestStatus          RequestStatus @default(PENDING)
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
+  concludedAt            DateTime?
+  completedAt            DateTime?
+  expiredAt              DateTime?
+  canceledAt             DateTime?
+  withdrawnAt            DateTime?
+  deletedAt              DateTime?  
+  invites                Invite[] 
+  driverRequestActions   DriverRequestAction[]
+  chattingRooms          ChattingRoom[]
+  quotations             Quotation[]
+  notifications          Notification[]
+  @@index([departureArea])
+  @@index([arrivalArea])
 }
 
-enum RequestStatement {
-  PENDING /// 견적 요청 대기 중 
-  CONFIRMED /// 매칭 완료
-  CANCELLED /// 취소됨
-  EXPIRED // 만료
+enum RequestStatus {
+  PENDING 
+  CONCLUDED
+  COMPLETE
+  EXPIRED
+  CANCELED   
+  WITHDRAWN
+}
+
+model Invite { 
+  id         String    @id @default(uuid()) 
+  requestId  String 
+  request    Request   @relation(fields: [requestId], references: [id], onDelete: Cascade) 
+  driverId   String 
+  driver     User      @relation(fields: [driverId], references: [id], onDelete: Cascade) 
+  createdAt  DateTime  @default(now()) 
+  canceledAt DateTime? 
+  @@unique([requestId, driverId]) 
+  @@index([driverId]) 
+} 
+
+model DriverRequestAction { 
+  id         String @id @default(uuid()) 
+  requestId  String 
+  request    Request @relation(fields: [requestId], references: [id], onDelete: Cascade) 
+  driverId   String 
+  driver     User @relation(fields: [driverId], references: [id], onDelete: Cascade) 
+  state      ActionState 
+  source     ActionSource 
+  note       String? 
+  createdAt  DateTime @default(now()) 
+  updatedAt  DateTime @updatedAt 
+  @@unique([requestId, driverId]) 
+  @@index([driverId, state]) 
+  @@index([requestId, state]) 
+} 
+
+enum ActionState { 
+  ACCEPTED 
+  REJECTED 
+} 
+
+enum ActionSource { 
+  GENERAL 
+  INVITED 
 }
 
 model ChattingRoom {
-  id                String            @id @default(uuid())
-  consumerId        String
-  consumer          User              @relation("RoomsByConsumer", fields: [consumerId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  consumerProfileId String
-  consumerProfile   ConsumerProfile   @relation(fields: [consumerProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  driverId          String
-  driver            User              @relation("RoomsByDriver", fields: [driverId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  driverProfileId   String
-  driverProfile     DriverProfile     @relation(fields: [driverProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  requestId         String
-  request           Request           @relation(fields: [requestId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  createdAt         DateTime          @default(now())
-  updatedAt         DateTime          @updatedAt
-  deletedAt         DateTime?
-  quotations        Quotation[]
-  messages          ChattingMessage[]
+  id              String          @id @default(uuid())
+  consumerId      String
+  consumer        User            @relation("RoomsByConsumer", fields: [consumerId], references: [id], onUpdate: Cascade, onDelete: Restrict)
+  driverId        String
+  driver          User            @relation("RoomsByDriver", fields: [driverId], references: [id], onUpdate: Cascade, onDelete: Restrict)
+  requestId       String
+  request         Request         @relation(fields: [requestId], references: [id], onUpdate: Cascade, onDelete: Restrict)
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
+  deletedAt       DateTime?
+  closedAt        DateTime?       
+  quotations      Quotation[]
+  messages        ChattingMessage[]
+  notifications   Notification[]
+  @@unique([requestId, driverId]) 
+  @@index([consumerId, createdAt]) 
+  @@index([driverId, createdAt])  
 }
 
 model ChattingMessage {
-  id             String       @id @default(uuid())
+  id             String        @id @default(uuid())
   chattingRoomId String
-  chattingRoom   ChattingRoom @relation(fields: [chattingRoomId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  content        String
-  messageType    MessageType
-  createdAt      DateTime     @default(now())
-  updatedAt      DateTime     @updatedAt
+  chattingRoom   ChattingRoom  @relation(fields: [chattingRoomId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   senderId       String
-  sender         User         @relation(fields: [senderId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  isRead         Boolean      @default(false)
+  sender         User          @relation(fields: [senderId], references: [id], onUpdate: Cascade, onDelete: Restrict)
+  messageType    MessageType
+  quotation      Quotation?
+  content        String?        @db.Text
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+  chatMessageReads ChatMessageRead[]
+  @@index([chattingRoomId, createdAt]) 
+}
+
+model ChatMessageRead {
+  messageId  String
+  message    ChattingMessage @relation(fields: [messageId], references: [id], onDelete: Cascade)
+  userId     String
+  user       User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  readAt     DateTime        @default(now())
+  @@id([messageId, userId])  
+  @@index([userId, readAt])
 }
 
 enum MessageType {
-  QUOTATION
   MESSAGE
+  QUOTATION
 }
 
-model Quotation {
-  id                 String             @id @default(uuid())
-  consumerId         String
-  consumer           User               @relation("QuotationsByConsumer", fields: [consumerId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  consumerProfileId  String
-  consumerProfile    ConsumerProfile    @relation(fields: [consumerProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  driverId           String
-  driver             User               @relation("QuotationsForDriver", fields: [driverId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  driverProfileId    String
-  driverProfile      DriverProfile      @relation(fields: [driverProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  chattingRoomId     String
-  chattingRoom       ChattingRoom       @relation(fields: [chattingRoomId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  requestId          String
-  request            Request            @relation(fields: [requestId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  departureAddress   String
-  departureFloor     Int
-  departureSize      Float
-  arrivalAddress     String
-  arrivalFloor       Int
-  arrivalSize        Float
-  requirements       String?
-  departureArea      Area
-  arrivalArea        Area
-  price              Int
-  quotationStatement QuotationStatement
-  createdAt          DateTime           @default(now())
-  updatedAt          DateTime           @updatedAt
-  deletedAt          DateTime?
-  reviews            Review[]
-}
+model Quotation { 
+ id                     String @id @default(uuid()) 
+ consumerId             String 
+ consumer               User @relation("QuotationsByConsumer", fields: [consumerId], references: [id], onUpdate: Cascade, onDelete: Restrict) 
+ driverId               String 
+ driver                 User @relation("QuotationsForDriver", fields: [driverId], references: [id], onUpdate: Cascade, onDelete: Restrict) 
+ chattingRoomId         String 
+ chattingRoom           ChattingRoom @relation(fields: [chattingRoomId], references: [id], onUpdate: Cascade, onDelete: Restrict) 
+ requestId              String 
+ request                Request @relation(fields: [requestId], references: [id], onUpdate: Cascade, onDelete: Restrict) 
+ serviceType            MoveType 
+ moveAt                 DateTime @db.Date 
+ departureAddress       String 
+ departureFloor         Int 
+ departurePyeong        Float 
+ departureElevator      Boolean 
+ arrivalAddress         String 
+ arrivalFloor           Int 
+ arrivalPyeong          Float 
+ arrivalElevator        Boolean 
+ additionalRequirements String? 
+ price                  Int 
+ status                 QuotationStatus @default(SUBMITTED)
+ previousQuotationId    String?
+ previousQuotation      Quotation?  @relation("QuotationRevisions", fields: [previousQuotationId], references: [id], onDelete: SetNull)
+ nextRevisions          Quotation[] @relation("QuotationRevisions")
+ selectedAt             DateTime? 
+ validUntil             DateTime? 
+ createdAt              DateTime @default(now()) 
+ updatedAt              DateTime @updatedAt 
+ deletedAt              DateTime? 
+ review                 Review?
+ chattingMessageId      String          @unique
+ chattingMessage        ChattingMessage @relation(fields: [chattingMessageId], references: [id], onUpdate: Cascade, onDelete: Restrict)
+ notifications          Notification[]
+ @@index([driverId, createdAt]) 
+ @@index([consumerId, createdAt]) 
+ @@index([requestId, createdAt]) 
+ @@index([chattingRoomId, createdAt]) 
+ } 
 
-enum QuotationStatement {
-  SUBMITTED /// 제출됨
-  ACCEPTED /// 수락됨
-  REJECTED /// 거절됨
-  EXPIRED /// 만료됨
-}
+ enum QuotationStatus { 
+ SUBMITTED 
+ REVISED 
+ WITHDRAWN 
+ SELECTED 
+ EXPIRED 
+ }
 
-model Review {
-  id                String          @id @default(uuid())
-  consumerId        String
-  consumer          User            @relation("ReviewsByConsumer", fields: [consumerId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  consumerProfileId String
-  consumerProfile   ConsumerProfile @relation("ReviewsFromConsumerProfile", fields: [consumerProfileId], references: [id], onUpdate: Cascade, onDelete: Restrict)
-  driverId          String
-  driver            User            @relation("ReviewsForDriver", fields: [driverId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  driverProfileId   String
-  driverProfile     DriverProfile   @relation("ReviewsForDriverProfile", fields: [driverProfileId], references: [id], onUpdate: Cascade, onDelete: Restrict)
-  content           String
-  rate              Int
-  quotationId       String
-  quotation         Quotation       @relation(fields: [quotationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  createdAt         DateTime        @default(now())
-  updatedAt         DateTime        @updatedAt
-  deletedAt         DateTime?
-}
+model Review { 
+ id            String @id @default(uuid()) 
+ consumerId    String 
+ consumer      User @relation("ReviewsByConsumer", fields: [consumerId], references: [id], onUpdate: Cascade, onDelete: Restrict) 
+ driverId      String 
+ driver        User @relation("ReviewsForDriver", fields: [driverId], references: [id], onUpdate: Cascade, onDelete: Restrict) 
+ content       String @db.Text
+ rating        Int 
+ quotationId   String @unique
+ quotation     Quotation @relation(fields: [quotationId], references: [id], onUpdate: Cascade, onDelete: Restrict) 
+ createdAt     DateTime @default(now()) 
+ updatedAt     DateTime @updatedAt 
+ deletedAt     DateTime? 
+ notifications Notification[]
+ }
 
 model Notification {
   id               String           @id @default(uuid())
   receiverId       String
-  receiver         User             @relation(fields: [receiverId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  content          String
-  createdAt        DateTime         @default(now())
-  isRead           Boolean          @default(false)
+  receiver         User             @relation("ReceivedNotifications", fields: [receiverId], references: [id], onDelete: Cascade)
+  senderId         String?
+  sender           User?            @relation("SentNotifications", fields: [senderId], references: [id], onDelete: SetNull)
+  content          String           @db.Text
   notificationType NotificationType
+  createdAt        DateTime         @default(now())
+  readAt           DateTime?        
+  requestId        String?
+  request          Request?         @relation(fields: [requestId], references: [id], onDelete: SetNull)
+  quotationId      String?
+  quotation        Quotation?       @relation(fields: [quotationId], references: [id], onDelete: SetNull)
+  chattingRoomId   String?
+  chattingRoom     ChattingRoom?    @relation(fields: [chattingRoomId], references: [id], onDelete: SetNull)
+  reviewId         String?
+  review           Review?          @relation(fields: [reviewId], references: [id], onDelete: SetNull)
+  @@index([receiverId, readAt])
+  @@index([receiverId, createdAt])
 }
 
 enum NotificationType {
@@ -291,4 +369,10 @@ enum NotificationType {
   QUOTATION_ACCEPTED
   NEW_MESSAGE
   REVIEW_RECEIVED
+  INVITE_RECEIVED
+  INVITE_CANCELLED
+  REQUEST_CONCLUDED
+  REQUEST_COMPLETED
+  REQUEST_EXPIRED
+  MOVE_DAY_REMINDER
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -163,6 +163,10 @@ model Request {
   departureArea          Area 
   arrivalArea            Area 
   requestStatus          RequestStatus @default(PENDING)
+  generalQuoteCount   Int @default(0)
+  invitedQuoteCount   Int @default(0)
+  generalQuoteLimit   Int @default(5)
+  invitedQuoteLimit   Int @default(3)
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
   concludedAt            DateTime?


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#34 

## #️⃣ 작업 내용
지정견적 지원을 위한 도메인 분리
- Invite: 요청별 지정 초대(기사 대상) 기록
- DriverRequestAction: 기사별 응답 상태(ACCEPTED/REJECTED) 및 출처(GENERAL/INVITED) 추적

요청 상태 체계화
- Request.requestStatus + concludedAt/completedAt/expiredAt/canceledAt/withdrawnAt 타임스탬프 추가
- 지역 매칭 성능을 위해 @@index([departureArea]), @@index([arrivalArea])

채팅/메시지 정리
- ChattingRoom 중복 방지: @@unique([requestId, driverId])
- 개인별 읽음 추적을 위해 ChatMessageRead(신규) 도입
- ChattingMessage에서 견적 메시지 연결: quotation Quotation?

견적 수명주기/버전 관리
- Quotation.status를 QuotationStatus(SUBMITTED/REVISED/WITHDRAWN/SELECTED/EXPIRED)로 확장
- 리비전 체인: previousQuotationId + self-relation(previousQuotation/nextRevisions)
- selectedAt, validUntil 추가
- 채팅 메시지와 1:1 연결: chattingMessageId

알림 확장
- 발신자/수신자 분리: sentNotifications / receivedNotifications
- Notification에 senderId, readAt, 그리고 원인 엔티티 FK(requestId/quotationId/chattingRoomId/reviewId) 추가

명명/관계 정리
- User.invitesAsDriver, User.driverRequestActions 등 의미 중심 네이밍 정리
- (주석) ConsumerProfile.areas → area 네이밍 전환 예정

## #️⃣ 변경 사항 체크리스트
- [x] 스키마 추가: Invite, DriverRequestAction, ChatMessageRead

- [x] 스키마 변경:
  - Request: 상태+타임스탬프 필드, 관계 필드(invites, driverRequestActions, notifications) 정리
  - ChattingRoom: @@unique([requestId, driverId]) 추가
  - ChattingMessage: quotation 연결, 읽음은 제거하고 ChatMessageRead로 분리
  - Quotation: 상태 확장, self-relation(리비전), chattingMessageId 추가
  - Notification: senderId, readAt, 원인 엔티티 FK 추가
  - User: sentNotifications, invitesAsDriver, driverRequestActions 등 관계 필드 정리
  - 인덱스 반영: 지역/시간/상태 축 조회에 필요한 인덱스 추가

- [x] 호환성 검토:
  - 제거/변경된 필드 사용처 정리(예: 메시지 isRead → ChatMessageRead)
  - 기존 단일 타겟 드라이버(targetDriver) 의존 로직 → Invite/DriverRequestAction 기반으로 치환
  -  onDelete/onUpdate 정책 점검: 핵심 엔티티 보존을 위해 Restrict/SetNull 전략 통일
 
 - [x] Prisma generate/format 정상 동작 확인

## #️⃣ 테스트 결과
- 로컬 마이그레이션 적용 및 prisma generate 성공
시나리오 검증
- 일반 견적: Request(PENDING) 작성 → 기사 피드 노출
- 지정 견적: Invite 생성 시 해당 기사 카드에 지정 뱃지 표시
- 기사 응답: DriverRequestAction
- REJECTED(GENERAL) → 받은요청 기본 제외
- 초대가 있으면 재노출(INVITED) 정책 구현 가능 확인
- 수락 시 채팅방: ACCEPTED 후 ChattingRoom 생성, 조합 유일성 보장
- 견적 메시지: Quotation 작성 ↔ ChattingMessage 연결(chattingMessageId)
- 상태 전이: Request concluded/complete/expired/canceled/withdrawn 시각 필드 세팅 확인
- 알림: Notification 생성 시 senderId, 원인 FK 설정 및 수신함 정렬/미읽음 조회

## #️⃣ 리뷰 요구사항 (선택)
먼저, 네이밍과 관계 설정에 대해 확인 부탁드립니다.
또한, Notification이 참조하는 원인 엔티티 세트(REQUEST, QUOTATION, CHATTING_ROOM, REVIEW)가 적절한지 검토 부탁드립니다. 누락되었거나 과한 참조가 있다면 의견을 부탁드립니다.
마지막으로, ConsumerProfile.areas를 단수의 area로 전환하는 부분에 대해 동의 여부와 마이그레이션 시점(롤아웃 계획 포함)에 대한 의견을 부탁드립니다.
