### PR TITLE
[Feat] Driver 프로필 등록 API 구현

### DIFF
--- a/src/modules/users/DTO/createDriverProfileBodySchema.ts
+++ b/src/modules/users/DTO/createDriverProfileBodySchema.ts
@@ -1,0 +1,32 @@
+import { AreaSchema, MoveTypeSchema } from '@/shared/constant/enums.schema';
+import { createZodDto } from '@anatine/zod-nestjs';
+import { z } from 'zod';
+
+export const createDriverProfileBodySchema = z
+  .object({
+    image: z.string().optional().nullable(),
+    nickname: z.string().trim().min(2, { message: '닉네임은 2글자 이상이어야 합니다.' }),
+    careerYears: z.coerce.number().int().min(0),
+    oneLiner: z
+      .string()
+      .trim()
+      .min(2, { message: '한줄소개는 2글자 이상이어야 합니다.' })
+      .max(50, { message: '한줄소개는 50자 이하이어야 합니다.' }),
+    description: z
+      .string()
+      .trim()
+      .min(2, { message: '상세설명은 2글자 이상이어야 합니다.' })
+      .max(1000, { message: '상세설명은 1000자 이하이어야 합니다.' }),
+    serviceTypes: z
+      .array(MoveTypeSchema)
+      .min(1, '최소 1개 이상의 서비스 유형을 선택해주세요.')
+      .transform((arr) => Array.from(new Set(arr))),
+    serviceAreas: z
+      .array(AreaSchema)
+      .min(1, '최소 1개 이상의 서비스 지역을 선택해주세요.')
+      .transform((arr) => Array.from(new Set(arr))),
+  })
+  .strict();
+
+export type CreateDriverProfileBody = z.infer<typeof createDriverProfileBodySchema>;
+export class CreateDriverProfileBodyDto extends createZodDto(createDriverProfileBodySchema) {}

--- a/src/modules/users/infra/prisma-driverProfile.repository.ts
+++ b/src/modules/users/infra/prisma-driverProfile.repository.ts
@@ -3,10 +3,42 @@ import { PrismaService } from '@/shared/prisma/prisma.service';
 import { Injectable } from '@nestjs/common';
 import { TransactionContext } from '@/shared/prisma/transaction-runner.interface';
 import { getDb } from '@/shared/prisma/get-db';
+import { CreateDriverProfileBody } from '../dto/createDriverProfileBodySchema';
+import { DriverProfileEntity } from '../types';
 
 @Injectable()
 export class PrismaDriverProfileRepository implements IDriverProfileRepository {
   constructor(private readonly prisma: PrismaService) {}
+
+  async createDriverProfile(
+    driverId: string,
+    body: CreateDriverProfileBody,
+    ctx?: TransactionContext,
+  ): Promise<DriverProfileEntity> {
+    const db = getDb(ctx, this.prisma);
+
+    return await db.driverProfile.create({
+      data: {
+        userId: driverId,
+        image: body.image ?? null,
+        nickname: body.nickname,
+        careerYears: String(body.careerYears), // Prisma 스키마가 String이므로 변환
+        oneLiner: body.oneLiner,
+        description: body.description,
+        driverServiceAreas: {
+          create: body.serviceAreas.map((a) => ({ serviceArea: a })),
+        },
+        driverServiceTypes: {
+          create: body.serviceTypes.map((t) => ({ serviceType: t })),
+        },
+      },
+
+      include: {
+        driverServiceAreas: true,
+        driverServiceTypes: true,
+      },
+    });
+  }
 
   async incrementLikeCount(driverId: string, ctx?: TransactionContext): Promise<void> {
     const db = getDb(ctx, this.prisma);

--- a/src/modules/users/interface/consumer.service.interface.ts
+++ b/src/modules/users/interface/consumer.service.interface.ts
@@ -1,17 +1,17 @@
 import { GetLikedDriversQuerySchemaDto } from '../dto/getLikedDriversQuerySchema';
-import { driverProfileEntity, userEntity, ConsumerProfileEntity } from '../types';
+import { DriverProfileEntity, userEntity, ConsumerProfileEntity } from '../types';
 import { Area, MoveType } from '@/shared/constant/values';
 import { CreateConsumerProfileBody } from '../dto/createConsumerProfileBodySchema';
 
 export interface LikedDriverEntity {
   id: userEntity['id'];
-  nickname: driverProfileEntity['nickname'];
-  rating: driverProfileEntity['rating'];
-  reviewCount: driverProfileEntity['reviewCount'];
-  careerYears: driverProfileEntity['careerYears'];
-  confirmedCount: driverProfileEntity['confirmedCount'];
-  likeCount: driverProfileEntity['likeCount'];
-  avatarUrl: driverProfileEntity['image'];
+  nickname: DriverProfileEntity['nickname'];
+  rating: DriverProfileEntity['rating'];
+  reviewCount: DriverProfileEntity['reviewCount'];
+  careerYears: DriverProfileEntity['careerYears'];
+  confirmedCount: DriverProfileEntity['confirmedCount'];
+  likeCount: DriverProfileEntity['likeCount'];
+  avatarUrl: DriverProfileEntity['image'];
   serviceAreas: Area[];
   serviceTypes: MoveType[];
   likedAt: Date;

--- a/src/modules/users/interface/driver.service.interface.ts
+++ b/src/modules/users/interface/driver.service.interface.ts
@@ -1,9 +1,11 @@
 import { AccessTokenPayload } from '@/shared/jwt/jwt.payload.schema';
-
+import { CreateDriverProfileBody } from '../dto/createDriverProfileBodySchema';
+import { DriverProfileEntity } from '../types';
 type LikeDriverResult = { liked: true } | { liked: false; message: 'Already liked' };
 type UnlikeDriverResult = { unliked: true } | { unliked: false; message: 'Already unliked' };
 
 export interface IDriverService {
+  createDriverProfile(driverId: string, body: CreateDriverProfileBody): Promise<DriverProfileEntity>;
   likeDriver(driverId: string, user: AccessTokenPayload): Promise<LikeDriverResult>;
   unlikeDriver(driverId: string, user: AccessTokenPayload): Promise<UnlikeDriverResult>;
 }

--- a/src/modules/users/interface/driverProfile.repository.interface.ts
+++ b/src/modules/users/interface/driverProfile.repository.interface.ts
@@ -1,6 +1,13 @@
 import { TransactionContext } from '@/shared/prisma/transaction-runner.interface';
+import { CreateDriverProfileBody } from '../dto/createDriverProfileBodySchema';
+import { DriverProfileEntity } from '../types';
 
 export interface IDriverProfileRepository {
+  createDriverProfile(
+    driverId: string,
+    body: CreateDriverProfileBody,
+    ctx?: TransactionContext,
+  ): Promise<DriverProfileEntity>;
   incrementLikeCount(driverId: string, ctx?: TransactionContext): Promise<void>;
   decrementLikeCount(driverId: string, ctx?: TransactionContext): Promise<void>;
 }

--- a/src/modules/users/interface/like.repository.interface.ts
+++ b/src/modules/users/interface/like.repository.interface.ts
@@ -1,12 +1,12 @@
 import { Area, MoveType } from '@/shared/constant/values';
 import { TransactionContext } from '@/shared/prisma/transaction-runner.interface';
 import { LikedDriversKey } from '@/shared/utils/cursor.helper';
-import { driverProfileEntity, likeEntity, userEntity } from '../types';
+import { DriverProfileEntity, likeEntity, userEntity } from '../types';
 
 export type LikeWithDriverAggregate = likeEntity & {
   driver: userEntity & {
     driverProfile:
-      | (Omit<driverProfileEntity, 'driverServiceAreas' | 'driverServiceTypes'> & {
+      | (Omit<DriverProfileEntity, 'driverServiceAreas' | 'driverServiceTypes'> & {
           driverServiceAreas: { serviceArea: Area }[];
           driverServiceTypes: { serviceType: MoveType }[];
         })

--- a/src/modules/users/types.ts
+++ b/src/modules/users/types.ts
@@ -14,7 +14,7 @@ export interface userEntity {
   deletedAt: Date | null;
 }
 
-export interface driverProfileEntity {
+export interface DriverProfileEntity {
   id: string;
   userId: string;
   image: string | null;

--- a/src/shared/utils/cookies.service.ts
+++ b/src/shared/utils/cookies.service.ts
@@ -54,7 +54,7 @@ export class CookiesService {
     const opts: CookieOptions = {
       httpOnly: true,
       secure: this.useSecure,
-      path: '/api/auth/refresh',
+      path: '/auth/refresh',
       sameSite,
       maxAge,
     };

--- a/test/http-test/profile.nijuuy.http
+++ b/test/http-test/profile.nijuuy.http
@@ -1,6 +1,6 @@
 ### 환경 변수
 @baseUrl = http://localhost:4000
-@accessToken = 
+@consumerAccessToken = 
 
 
 ### 공통 헤더 (필요 시 복사해서 각 요청에 붙여 사용)
@@ -24,7 +24,7 @@ Content-Type: application/json
 
 ###
 POST {{baseUrl}}/consumers/profile
-Cookie: {{accessToken}}
+Cookie: {{consumerAccessToken}}
 Content-Type: application/json
 
 {
@@ -35,7 +35,7 @@ Content-Type: application/json
 
 ### 1-1) 소비자 프로필 등록 - image 없이(201)
 POST {{baseUrl}}/consumers/profile
-Cookie: {{accessToken}}
+Cookie: {{consumerAccessToken}}
 Content-Type: application/json
 
 {
@@ -45,7 +45,7 @@ Content-Type: application/json
 
 ### 1-2) 소비자 프로필 등록 - 중복 시도 (409 기대)
 POST {{baseUrl}}/consumers/profile
-Cookie: {{accessToken}}
+Cookie: {{consumerAccessToken}}
 Content-Type: application/json
 
 {
@@ -64,3 +64,99 @@ Cookie:
   "areas": "SEOUL"
 }
 
+
+################################################################
+# 2) 드라이버 로그인 (쿠키 받기)
+################################################################
+POST {{baseUrl}}/auth/signin
+Content-Type: application/json
+
+{
+  "email": "driver6@test.com",
+  "password": "password123",
+  "role": "DRIVER"
+}
+
+### 위 요청 응답의 Set-Cookie 에서 access_token=... 전체를 복사해 아래 변수에 넣어주세요.
+@driverAccessToken = access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2Njk3ZGI2ZC1kMWFlLTQwNGQtOTc2OS03YTEzNjBkZDU5NjciLCJqdGkiOiJiNDdlODJlYS0xNTRkLTRjZjAtOWQ3Yy1iZWIyMDhjZjU3OTgiLCJyb2xlIjoiRFJJVkVSIiwiaWF0IjoxNzYwNDMxNjU5LCJleHAiOjE3NjA0MzI1NTksImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6NDAwMCJ9.WYnfqByVa9yCZEC5YT3lxSev-ghkr5UAbh3YcJQU0Mg;
+
+################################################################
+# 3) 드라이버 프로필 등록 - 성공(201)
+################################################################
+POST {{baseUrl}}/drivers/profile
+Cookie: {{driverAccessToken}}
+Content-Type: application/json
+
+{
+  "image": "https://cdn.example.com/driver.png",
+  "nickname": "이사왕",
+  "careerYears": 5,
+  "oneLiner": "빠르고 안전하게!",
+  "description": "10년 경력의 이사 전문가입니다.",
+  "serviceTypes": ["HOME_MOVE", "OFFICE_MOVE"],
+  "serviceAreas": ["SEOUL", "GYEONGGI"]
+}
+
+################################################################
+# 3-1) 드라이버 프로필 등록 - 이미지 없이(201)
+################################################################
+POST {{baseUrl}}/drivers/profile
+Cookie: {{driverAccessToken}}
+Content-Type: application/json
+
+{
+  "nickname": "포장이사123",
+  "careerYears": 0,
+  "oneLiner": "정직한 견적",
+  "description": "초보지만 성실히 하겠습니다!",
+  "serviceTypes": ["HOME_MOVE"],
+  "serviceAreas": ["SEOUL"]
+}
+
+################################################################
+# 3-2) 드라이버 프로필 등록 - 중복 시도(409 기대)
+################################################################
+POST {{baseUrl}}/drivers/profile
+Cookie: {{driverAccessToken}}
+Content-Type: application/json
+
+{
+  "nickname": "이사왕",
+  "careerYears": 5,
+  "oneLiner": "빠르고 안전하게!",
+  "description": "중복 생성 테스트",
+  "serviceTypes": ["HOME_MOVE"],
+  "serviceAreas": ["SEOUL"]
+}
+
+################################################################
+# 3-3) 드라이버 프로필 등록 - 미인증(401 기대)
+################################################################
+POST {{baseUrl}}/drivers/profile
+Content-Type: application/json
+
+{
+  "nickname": "무면허",
+  "careerYears": 1,
+  "oneLiner": "테스트",
+  "description": "테스트",
+  "serviceTypes": ["HOME_MOVE"],
+  "serviceAreas": ["SEOUL"]
+}
+
+################################################################
+# 3-4) 드라이버 프로필 등록 - 잘못된 역할(403 기대)
+# (컨슈머 쿠키로 드라이버 프로필 생성 시도)
+################################################################
+POST {{baseUrl}}/drivers/profile
+Cookie: {{consumerAccessToken}}
+Content-Type: application/json
+
+{
+  "nickname": "권한오류테스트",
+  "careerYears": 2,
+  "oneLiner": "권한체크",
+  "description": "컨슈머 쿠키로 드라이버 프로필 생성 시도",
+  "serviceTypes": ["HOME_MOVE"],
+  "serviceAreas": ["SEOUL"]
+}

--- a/test/http-test/yujin.http
+++ b/test/http-test/yujin.http
@@ -11,7 +11,7 @@ POST {{host}}/auth/signup
 Content-Type: application/json
 
 {
-  "email": "consumer10@test.com",
+  "email": "consumer12@test.com",
   "password": "password123",
   "passwordConfirm": "password123",
   "name": "김소비",
@@ -25,7 +25,7 @@ POST {{host}}/auth/signup
 Content-Type: application/json
 
 {
-  "email": "driver1@test.com",
+  "email": "driver6@test.com",
   "password": "password123",
   "passwordConfirm": "password123",
   "name": "박기사",


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#6 

## #️⃣ 작업 내용
- 기사 프로필 등록 API 구현
- POST /drivers/profile
- AccessTokenGuard, RolesGuard('DRIVER') 적용
- Zod 스키마(createDriverProfileBodySchema)로 요청 검증
- DriverService.createDriverProfile 로직 추가
- 유저 존재 여부 검증 (NotFoundException)
- 중복 프로필 방지 (ConflictException + Prisma P2002 매핑)
- PrismaDriverProfileRepository 구현
- image, nickname, careerYears, oneLiner, description, serviceTypes, serviceAreas 저장

## #️⃣ 변경 사항 체크리스트
- [x] 컨트롤러: POST /drivers/profile 엔드포인트 생성
- [x] AccessTokenGuard + RolesGuard + @RequireRoles('DRIVER') 적용
- [x] Zod Validation Pipe 연결
- [x] 서비스 계층 로직 추가 (createDriverProfile)
- [x] 레포지토리 계층 구현 (PrismaDriverProfileRepository)
- [x] 중복 예외 처리 (ConflictException, P2002)
- [x] test.http 요청 시 201 / 409 / 401 / 403 케이스 정상 동작 확인

## #️⃣ 테스트 결과

| 시나리오 | 입력 | 기대 결과 | 실제 결과 |
|-----------|--------|-------------|-------------|
| ✅ 최초 등록 | 유효한 쿠키 + body | 201 Created | ✅ 성공 |
| ⚠️ 중복 등록 | 동일 driverId | 409 Conflict | ✅ 성공 |
| ❌ 미인증 | 쿠키 없음 | 401 Unauthorized | ✅ 성공 |
| ❌ 잘못된 role | CONSUMER 쿠키로 요청 | 403 Forbidden | ✅ 성공 |## #️⃣ 리뷰 요구사항 (선택)
추가로 개선할 부분이나 네이밍 관련 피드백 있으면 부탁드립니다!