### PR TITLE
fix: 프로필 미등록 시 404 에러처리 및 null 처리

### DIFF
--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -27,7 +27,7 @@ export class UsersController {
         user.driverProfile.driverServiceAreas?.map((a) => a.serviceArea),
       );
     } else {
-      throw new NotFoundException('프로필이 없습니다.');
+      return { ...user, driverProfile: null, consumerProfile: null };
     }
   }
 

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -17,6 +17,10 @@ export class UsersService {
   async getUserWithProfile(userId: string) {
     const user = await this.userRepository.getProfileById(userId);
     if (!user) throw new NotFoundException('유저를 찾을 수 없습니다.');
+
+    if (!user.consumerProfile || !user.driverProfile) {
+      throw new NotFoundException('프로필 정보를 찾을 수 없습니다.');
+    }
     return user;
   }
 


### PR DESCRIPTION
## 개요
유저의 프로필이 존재하지않을경우  500 에러가 뜨는상황에서 404 에러가 뜨도록 변경하였음
또한 유저프로필이 존재하지않을경우 null 값을 의도적으로 주면서 구조의 안정성을챙김

## 관련 이슈
#59 

## 바뀐 점
service에서의 에러 추가
서비스에서 막아놨긴했지만 혹시모를 없을경우 null로 처리.

## 테스트
DB를 날림으로써 테스트는 못해보지만 현재 로직상 유저의 프로필이 존재하지않을 경우 404 에러가 뜰 거라 예상이됨
