### PR TITLE
feat: 드라이버 상세 조회 API 구현 #74

### DIFF
--- a/src/modules/requests/infra/prisma-invite.repository.ts
+++ b/src/modules/requests/infra/prisma-invite.repository.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { IInviteRepository } from '../interface/invite.repository.interface';
 import { getDb } from '@/shared/prisma/get-db';
 import { TransactionContext } from '@/shared/prisma/transaction-runner.interface';
+import { InviteEntity } from '../types';
 
 @Injectable()
 export class PrismaInviteRepository implements IInviteRepository {
@@ -37,5 +38,17 @@ export class PrismaInviteRepository implements IInviteRepository {
       select: { driverId: true },
     });
     return new Set(rows.map((r) => r.driverId));
+  }
+
+  async findByRequestAndDriver(
+    requestId: string,
+    driverId: string,
+    ctx?: TransactionContext,
+  ): Promise<InviteEntity | null> {
+    const db = getDb(ctx, this.prisma);
+
+    return await db.invite.findUnique({
+      where: { requestId_driverId: { requestId, driverId } },
+    });
   }
 }

--- a/src/modules/requests/interface/invite.repository.interface.ts
+++ b/src/modules/requests/interface/invite.repository.interface.ts
@@ -1,8 +1,10 @@
 import { TransactionContext } from '@/shared/prisma/transaction-runner.interface';
+import { InviteEntity } from '../types';
 
 export interface IInviteRepository {
   insertIfAbsent(requestId: string, driverId: string, ctx?: TransactionContext): Promise<boolean>;
   findInvitedDriverIds(consumerId: string, driverIds: string[]): Promise<Set<string>>;
+  findByRequestAndDriver(requestId: string, driverId: string, ctx?: TransactionContext): Promise<InviteEntity | null>;
 }
 
 export const INVITE_REPOSITORY = 'IInviteRepository';

--- a/src/modules/users/domain/driver.mapper.ts
+++ b/src/modules/users/domain/driver.mapper.ts
@@ -1,5 +1,32 @@
 import { DriverAggregate } from '../interface/driverProfile.repository.interface';
-import { DriverListItem } from '../interface/driver.service.interface';
+import { DriverListItem, PublicDriverProfile } from '../interface/driver.service.interface';
+import { DriverServiceAreaEntity, DriverServiceTypeEntity } from '../types';
+import { DriverProfileEntity } from '../types';
+
+const mapAreas = (areas: DriverServiceAreaEntity[]) => areas.map((a) => a.serviceArea);
+const mapTypes = (types: DriverServiceTypeEntity[]) => types.map((t) => t.serviceType);
+
+export function toPublicDriverProfile(e: DriverProfileEntity): PublicDriverProfile {
+  const { driverServiceAreas, driverServiceTypes } = e;
+
+  const publicProfile: PublicDriverProfile = {
+    id: e.id,
+    userId: e.userId,
+    image: e.image,
+    nickname: e.nickname,
+    oneLiner: e.oneLiner,
+    careerYears: e.careerYears,
+    rating: e.rating,
+    reviewCount: e.reviewCount,
+    confirmedCount: e.confirmedCount,
+    likeCount: e.likeCount,
+    description: e.description,
+    serviceAreas: mapAreas(driverServiceAreas ?? []),
+    serviceTypes: mapTypes(driverServiceTypes ?? []),
+  } satisfies PublicDriverProfile;
+
+  return publicProfile;
+}
 
 export function toDriverListItem(row: DriverAggregate, isInvitedByMe: boolean): DriverListItem {
   return {

--- a/src/modules/users/driver.controller.ts
+++ b/src/modules/users/driver.controller.ts
@@ -41,6 +41,18 @@ export class DriverController {
     return this.driverService.getDrivers(user, query);
   }
 
+  @Get(':driverId')
+  @ApiOperation({ summary: '드라이버 프로필 조회' })
+  @ApiParam({ name: 'driverId', type: 'string', format: 'uuid', required: true, description: 'Driver user ID' })
+  @ApiResponse({ status: 200, description: '드라이버 프로필 조회 성공' })
+  @UseGuards(OptionalAccessTokenGuard)
+  async getDriverProfile(
+    @Param(new ZodValidationPipe(driverIdParamSchema)) params: DriverIdParam,
+    @AuthUserOptional() user: AccessTokenPayload | null,
+  ) {
+    return this.driverService.getDriverProfile(params.driverId, user);
+  }
+
   @Post('profile')
   @ApiOperation({ summary: '드라이버 프로필 등록' })
   @ApiResponse({ status: 201, description: '드라이버 프로필 등록 성공' })

--- a/src/modules/users/infra/prisma-driverProfile.repository.ts
+++ b/src/modules/users/infra/prisma-driverProfile.repository.ts
@@ -103,4 +103,16 @@ export class PrismaDriverProfileRepository implements IDriverProfileRepository {
       data: { likeCount: { decrement: 1 } },
     });
   }
+
+  async findById(driverId: string, ctx?: TransactionContext): Promise<DriverProfileEntity | null> {
+    const db = getDb(ctx, this.prisma);
+
+    return db.driverProfile.findUnique({
+      where: { userId: driverId },
+      include: {
+        driverServiceAreas: true,
+        driverServiceTypes: true,
+      },
+    });
+  }
 }

--- a/src/modules/users/interface/driver.service.interface.ts
+++ b/src/modules/users/interface/driver.service.interface.ts
@@ -1,8 +1,8 @@
 import { AccessTokenPayload } from '@/shared/jwt/jwt.payload.schema';
 import { CreateDriverProfileBody } from '../dto/createDriverProfileBodySchema';
-import { DriverProfileEntity, userEntity } from '../types';
 import { GetDriverListQuery } from '../dto/getDriverListQuerySchema';
-import { Area, MoveType } from '@/shared/constant/values';
+import { DriverProfileEntity, userEntity } from '../types';
+import { Area, MoveType } from '@shared/constant/values';
 
 export interface DriverUserSummary {
   id: userEntity['id'];
@@ -11,19 +11,19 @@ export interface DriverUserSummary {
   createdAt: userEntity['createdAt'];
 }
 
-export interface DriverProfileSummary {
-  userId: DriverProfileEntity['userId'];
-  image: DriverProfileEntity['image'];
-  nickname: DriverProfileEntity['nickname'];
-  oneLiner: DriverProfileEntity['oneLiner'];
-  careerYears: DriverProfileEntity['careerYears'];
-  rating: DriverProfileEntity['rating'];
-  reviewCount: DriverProfileEntity['reviewCount'];
-  confirmedCount: DriverProfileEntity['confirmedCount'];
-  likeCount: DriverProfileEntity['likeCount'];
+export type PublicDriverProfile = Omit<
+  DriverProfileEntity,
+  'createdAt' | 'updatedAt' | 'deletedAt' | 'driverServiceAreas' | 'driverServiceTypes'
+> & {
   serviceAreas: Area[];
   serviceTypes: MoveType[];
-}
+};
+
+export type DriverProfileDetail = PublicDriverProfile & {
+  isInvitedByMe: boolean;
+};
+
+export type DriverProfileSummary = Omit<PublicDriverProfile, 'id' | 'description'> & {};
 
 export interface DriverListItem {
   user: DriverUserSummary;
@@ -42,6 +42,7 @@ type UnlikeDriverResult = { unliked: true } | { unliked: false; message: 'Alread
 
 export interface IDriverService {
   getDrivers(user: AccessTokenPayload | null, query: GetDriverListQuery): Promise<GetDriverListResponse>;
+  getDriverProfile(driverId: string, user: AccessTokenPayload | null): Promise<DriverProfileDetail>;
   createDriverProfile(driverId: string, body: CreateDriverProfileBody): Promise<DriverProfileEntity>;
   likeDriver(driverId: string, user: AccessTokenPayload): Promise<LikeDriverResult>;
   unlikeDriver(driverId: string, user: AccessTokenPayload): Promise<UnlikeDriverResult>;

--- a/src/modules/users/interface/driverProfile.repository.interface.ts
+++ b/src/modules/users/interface/driverProfile.repository.interface.ts
@@ -51,6 +51,7 @@ export interface IDriverProfileRepository {
   incrementLikeCount(driverId: string, ctx?: TransactionContext): Promise<void>;
   decrementLikeCount(driverId: string, ctx?: TransactionContext): Promise<void>;
   findDrivers(input: RepoFindDriversInput): Promise<DriverAggregate[]>;
+  findById(driverId: string, ctx?: TransactionContext): Promise<DriverProfileEntity | null>;
 }
 
 export const DRIVER_PROFILE_REPOSITORY = 'IDriverProfileRepository';

--- a/src/modules/users/types.ts
+++ b/src/modules/users/types.ts
@@ -29,8 +29,8 @@ export interface DriverProfileEntity {
   createdAt: Date;
   updatedAt: Date;
   deletedAt: Date | null;
-  driverServiceAreas: driverServiceAreaEntity[];
-  driverServiceTypes: driverServiceTypeEntity[];
+  driverServiceAreas: DriverServiceAreaEntity[];
+  driverServiceTypes: DriverServiceTypeEntity[];
 }
 
 export interface ConsumerProfileEntity {
@@ -44,13 +44,13 @@ export interface ConsumerProfileEntity {
   deletedAt: Date | null;
 }
 
-export interface driverServiceAreaEntity {
+export interface DriverServiceAreaEntity {
   id: string;
   driverProfileId: string;
   serviceArea: Area;
 }
 
-export interface driverServiceTypeEntity {
+export interface DriverServiceTypeEntity {
   id: string;
   driverProfileId: string;
   serviceType: MoveType;

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -19,6 +19,7 @@ import { DRIVER_SERVICE } from './interface/driver.service.interface';
 import { CONSUMER_SERVICE } from './interface/consumer.service.interface';
 import { CONSUMER_PROFILE_REPOSITORY } from './interface/consumerProfile.repository.interface';
 import { INVITE_REPOSITORY } from '../requests/interface/invite.repository.interface';
+import { REQUEST_REPOSITORY } from '../requests/interface/request.repository.interface';
 // infra implementations
 import { PrismaUserRepository } from './infra/prisma-user.repository';
 import { PrismaDriverProfileRepository } from './infra/prisma-driverProfile.repository';
@@ -27,6 +28,8 @@ import { CookiesService } from '@/shared/utils/cookies.service';
 import { HashingModule } from '@/shared/hashing/hashing.module';
 import { PrismaConsumerProfileRepository } from './infra/prisma-consumerProfile.repository';
 import { PrismaInviteRepository } from '../requests/infra/prisma-invite.repository';
+import { PrismaRequestRepository } from '../requests/infra/prisma-request.repository';
+
 @Module({
   imports: [PrismaModule, HashingModule],
   controllers: [UsersController, DriverController, ConsumerController],
@@ -39,6 +42,7 @@ import { PrismaInviteRepository } from '../requests/infra/prisma-invite.reposito
     { provide: CONSUMER_SERVICE, useClass: ConsumerService },
     { provide: CONSUMER_PROFILE_REPOSITORY, useClass: PrismaConsumerProfileRepository },
     { provide: INVITE_REPOSITORY, useClass: PrismaInviteRepository },
+    { provide: REQUEST_REPOSITORY, useClass: PrismaRequestRepository },
     CookiesService,
   ],
   exports: [UsersService, USER_REPOSITORY, DRIVER_SERVICE],

--- a/test/http-test/profile.nijuuy.http
+++ b/test/http-test/profile.nijuuy.http
@@ -179,3 +179,9 @@ Accept: application/json
 ### 2-1) 로그인(소비자) + 필터 조합
 GET {{baseUrl}}/drivers?take=5&area=GYEONGGI&type=OFFICE_MOVE&sort=CONFIRMED_DESC
 Accept: application/json
+
+
+### ------------------------------------------------------------
+### 드라이버 상세조회
+GET {{baseUrl}}/drivers/2b746e3c-cc3b-4276-b430-8f71d01d3b03
+Content-Type: application/json


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#74 

## #️⃣ 작업 내용
- 드라이버 프로필 상세 조회 API 신규 구현 (GET /drivers/:driverId)
    - DriverProfileRepository.findById()로 기사 프로필 조회
    - 프로필이 존재하지 않을 경우 NotFoundException 처리
    - OptionalAccessTokenGuard 적용으로 로그인/비로그인 모두 접근 가능
    - @AuthUserOptional() 데코레이터로 사용자 정보 선택적 주입
- 지정견적 여부(isInvitedByMe) 반환 로직 추가
    - 로그인 사용자 중 CONSUMER만 초대 여부 확인
    - RequestRepository.findPendingByConsumerId()로 활성 요청 조회
    - InviteRepository.findByRequestAndDriver(requestId, driverId)로 지정견적 여부 확인
    - 초대 존재 시 isInvitedByMe = true
- 매퍼 및 타입 정의
    - toPublicDriverProfile() 매퍼 작성 → DriverProfileEntity → PublicDriverProfile 변환
    - DriverProfileDetail = PublicDriverProfile & { isInvitedByMe: boolean } 타입 추가

## #️⃣ 테스트 결과
| 시나리오 | 입력 | 기대 결과 | 실제 결과 |
|-----------|--------|-------------|-------------|
| ✅ 로그인 X 상태 | GET /drivers/:id | 프로필 정보만 반환 (`isInvitedByMe=false`) | ✅ 성공 |
| ✅ 로그인 CONSUMER, 지정견적 보냄 | GET /drivers/:id | `isInvitedByMe=true` | ✅ 성공 |
| ✅ 로그인 CONSUMER, 미초대 | GET /drivers/:id | `isInvitedByMe=false` | ✅ 성공 |
| ✅ 로그인 DRIVER | GET /drivers/:id | `isInvitedByMe=false` | ✅ 성공 |
| ❌ 존재하지 않는 드라이버 ID | GET /drivers/:invalid | 404 Not Found | ✅ 성공 |

## #️⃣ 변경 사항 체크리스트
- [x] DriverProfileRepository.findById() 구현
- [x] InviteRepository.findByRequestAndDriver() 구현
- [x] RequestRepository.findPendingByConsumerId() 활용
- [x]  DriverService.getDriverProfile() 서비스 로직 작성
- [x] OptionalAccessTokenGuard + @AuthUserOptional() 적용
- [x] PublicDriverProfile, DriverProfileDetail 타입 추가
- [x] toPublicDriverProfile() 매퍼 작성

