### PR TITLE
[FIX] id 기본값 누락으로 인한 삽입 오류 해결 #76

### DIFF
--- a/src/modules/requests/infra/prisma-invite.repository.ts
+++ b/src/modules/requests/infra/prisma-invite.repository.ts
@@ -13,11 +13,11 @@ export class PrismaInviteRepository implements IInviteRepository {
     const db = getDb(ctx, this.prisma);
 
     const rows = await db.$queryRaw<{ inserted: number }[]>`
-      INSERT INTO "Invite" ("requestId", "driverId")
-      VALUES (${requestId}, ${driverId})
-      ON CONFLICT ("requestId", "driverId") DO NOTHING
-      RETURNING 1 AS inserted
-    `;
+    INSERT INTO "Invite" ("id","requestId","driverId")
+    VALUES (gen_random_uuid(), ${requestId}, ${driverId})
+    ON CONFLICT ("requestId","driverId") DO NOTHING
+    RETURNING 1 AS inserted
+  `;
 
     return rows.length > 0;
   }

--- a/test/http-test/request.nijuuy.http
+++ b/test/http-test/request.nijuuy.http
@@ -6,8 +6,8 @@
 @host = http://localhost:4000
 
 # @name accessCookieName
-@cookie = access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5NDhhNjczOS1iOGRjLTRiYTMtYWUyYS0yOTQ4NDQzM2YzZTkiLCJqdGkiOiJjMTE4ZjgxOS1jYTYzLTQ3MzMtYTIzMi05YTU1ZmJiY2Y2NzkiLCJyb2xlIjoiQ09OU1VNRVIiLCJpYXQiOjE3NjA0MTU2NjYsImV4cCI6MTc2MDQxNjU2NiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo0MDAwIn0.gnOkLb-ObTtR26lspVqpw0GNXU8HWZrm1l8NE6-2eXQ;
-@driverId = 2e72d584-1cc5-46a8-bf12-8a156c86b59d
+@cookie = access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjNmQxOTAyNS1jNzJlLTQxYTgtYmM3Zi0yMWNkOGZhMzA3MzYiLCJqdGkiOiI0OGZiYWZjNS00Yjk0LTQ3YmItOWFkZS1mMTI2YmIzNjgyNDIiLCJyb2xlIjoiQ09OU1VNRVIiLCJpYXQiOjE3NjExMTcwNzMsImV4cCI6MTc2MTExNzk3MywiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo0MDAwIn0.CMZddAoyCHrXc8xztrRNDCZKCQCd9bvbBIayJBmVzR8;
+@driverId = 2b746e3c-cc3b-4276-b430-8f71d01d3b03
 
 # ========================================================
 # 1. 견적 요청 생성 (POST /requests)
@@ -18,7 +18,7 @@ POST {{host}}/auth/signin
 Content-Type: application/json
 
 {
-  "email": "consumer7@test.com",
+  "email": "consumer@test.com",
   "password": "password123",
   "role": "CONSUMER"
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#76 

## #️⃣ 작업 내용
- 지정초대 API(POST /requests/invite/:driverId) 호출 시 Invite 레코드 삽입 시 발생하던 23502 (NOT NULL violation) 오류 수정
- insertIfAbsent() 내부 raw query를 수정하여 id를 명시적으로 생성하도록 변경
```
INSERT INTO "Invite" ("id","requestId","driverId")
VALUES (gen_random_uuid(), ${requestId}, ${driverId})
ON CONFLICT ("requestId","driverId") DO NOTHING
RETURNING 1 AS inserted
```
- Prisma 스키마에는 @default(uuid())가 지정되어 있었으나, 실제 DB에서 기본값이 반영되지 않아 id가 null로 삽입되던 문제를 임시적으로 해결

## #️⃣ 테스트 결과
| 시나리오 | 입력 | 기대 결과 | 실제 결과 |
|-----------|--------|-------------|-------------|
| ✅ 정상 지정초대 요청 | 유효한 consumer 쿠키 + driverId | Invite 생성 성공 (201) | ✅ 성공 |
| ⚠️ 중복 지정초대 요청 | 동일 driverId 재요청 | 중복 삽입 방지 (alreadyExisted: true) | ✅ 성공 |
| ❌ 비로그인 상태 | 쿠키 없음 | 401 Unauthorized | ✅ 성공 |
| ❌ 존재하지 않는 드라이버 ID | 잘못된 driverId | 404 Not Found | ✅ 성공 |

## #️⃣ 변경 사항 체크리스트
 - InviteRepository.insertIfAbsent() raw query 수정
 - gen_random_uuid() 함수 사용 (DB 확장 모듈 pgcrypto 필요)
 - 로컬 환경 및 RDS 환경에서 정상 삽입 확인
 - 기존 로직(ON CONFLICT 중복 방지) 유지

## 💡 추후 작업 권장:
- DB 스키마 기본값(ALTER TABLE "Invite" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();) 복구
- Prisma 스키마와 DB 실제 스키마 일치 여부(prisma migrate diff) 점검
