### PR TITLE
[FIX] id 기본값 누락으로 인한 삽입 오류(23502) 해결 (gen_random_uuid 사용) #79

### DIFF
--- a/src/modules/users/infra/prisma-like.repository.ts
+++ b/src/modules/users/infra/prisma-like.repository.ts
@@ -13,8 +13,8 @@ export class PrismaLikeRepository implements ILikeRepository {
     const db = getDb(ctx, this.prisma);
 
     const result = await db.$queryRaw<{ inserted: number }[]>`
-      INSERT INTO "Like" ("consumerId", "driverId")
-      VALUES (${consumerId}, ${driverId})
+      INSERT INTO "Like" ("id","consumerId", "driverId")
+      VALUES (gen_random_uuid(), ${consumerId}, ${driverId})
       ON CONFLICT ("consumerId", "driverId") DO NOTHING
       RETURNING 1 AS inserted
     `;

--- a/test/http-test/like.nijuuy.http
+++ b/test/http-test/like.nijuuy.http
@@ -7,8 +7,8 @@
 @moverPassword = moverPw123!
 
 # 테스트용 대상 드라이버 ID (DB에 실제 존재하는 DRIVER 사용자 ID)
-@driverId = 2e72d584-1cc5-46a8-bf12-8a156c86b59d
-@cookie = access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5ZTJlNGI3ZS0zYjJhLTQ1ODMtYmMxMS02Yzc4ZWMzMDgzMzYiLCJqdGkiOiIwMDAyYTI1Yy02ZmEwLTQ3MzUtOTI4Yi0wNzMxZDA2MGY4NzQiLCJyb2xlIjoiQ09OU1VNRVIiLCJpYXQiOjE3NjAzMzg4MTEsImV4cCI6MTc2MDMzOTcxMSwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo0MDAwIn0.1wQMOXExJsEzxTyRT89Z52uendl1VHeR5Qi1jiduZvw;
+@driverId = 98a33478-72bf-454c-a87b-008587c8b37d
+@cookie = access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjNmQxOTAyNS1jNzJlLTQxYTgtYmM3Zi0yMWNkOGZhMzA3MzYiLCJqdGkiOiI4NDk4Zjg3Ni01NzgxLTQ4MGQtODVkMS1kZDA3MGU1NzVmNDIiLCJyb2xlIjoiQ09OU1VNRVIiLCJpYXQiOjE3NjEyMDUwNjcsImV4cCI6MTc2MTIwNTk2NywiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo0MDAwIn0.sK7Y6lYyzLo3gWIP8OxgaZNp27YUGnqh4gfN3bZ4YS4;
 
 ### 좋아요 테스트(comsumer -> driver)
 POST {{baseUrl}}/drivers/{{driverId}}/likes


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#79 

## #️⃣ 작업 내용
- 좋아요 생성 시 발생하던 `23502 (NOT NULL violation)` 오류를 수정
- Like 레포지토리의 raw insert에서 `id`를 명시적으로 생성하도록 변경
  ```
  INSERT INTO "Like" ("id","userId","targetId", "createdAt")
  VALUES (gen_random_uuid(), $1, $2, now())
  ON CONFLICT ("userId","targetId") DO NOTHING
  RETURNING 1 AS inserted
  ```
- Prisma 스키마에는 @default(uuid())가 지정돼 있으나 실제 DB 기본값 미적용으로 인해 id=null 삽입되던 문제를 코드 레벨에서 임시 차단

## #️⃣ 테스트 결과 
시나리오 | 입력 | 기대 결과 | 실제 결과
-- | -- | -- | --
✅ 정상 좋아요 생성 | 유효한 쿠키 + targetId | Like 생성 성공 (201) | ✅ 성공
⚠️ 중복 좋아요 요청 | 동일 targetId 재요청 | 중복 삽입 방지 (alreadyExisted: true) | ✅ 성공
❌ 비로그인 상태 | 쿠키 없음 | 401 Unauthorized | ✅ 성공
❌ 존재하지 않는 대상 | 잘못된 targetId | 404 Not Found | ✅ 성공

## #️⃣ 변경 사항 체크리스트
- [x] LikeRepository.insertIfAbsent() 또는 해당 raw insert 로직에서 id 명시적 생성
- [x] 로컬/RDS 모두에서 삽입 정상 동작 확인