### PR TITLE
[FEAT] 채팅 메시지 읽음 처리 WebSocket 이벤트 추가

### DIFF
--- a/src/modules/chat/chat.module.ts
+++ b/src/modules/chat/chat.module.ts
@@ -21,6 +21,8 @@ import { ChatRoomWsService } from './ws/room.service';
 import { QUOTATION_REPOSITORY } from '../quotations/interface/quotation.repository.interface';
 import { PrismaQuotationRepository } from '../quotations/infra/prisma-quotation.repository';
 import { PrismaChattingMessagesRepository } from './infra/prisma.chatting-message.repository';
+import { CHATTING_MESSAGES_READ_REPOSITORY } from './interface/chatting-messages-read.repository.interface';
+import { PrismaChattingMessagesReadRepository } from './infra/prisma.chatting-messages-read.repository';
 
 @Module({
   imports: [JwtModule, CookieModule, PrismaModule],
@@ -37,6 +39,7 @@ import { PrismaChattingMessagesRepository } from './infra/prisma.chatting-messag
     { provide: TRANSACTION_RUNNER, useClass: PrismaTransactionRunner },
     { provide: CHATTING_MESSAGES_REPOSITORY, useClass: PrismaChattingMessagesRepository },
     { provide: QUOTATION_REPOSITORY, useClass: PrismaQuotationRepository },
+    { provide: CHATTING_MESSAGES_READ_REPOSITORY, useClass: PrismaChattingMessagesReadRepository },
   ],
   exports: [ChatGateway],
 })

--- a/src/modules/chat/infra/prisma.chatting-message.repository.ts
+++ b/src/modules/chat/infra/prisma.chatting-message.repository.ts
@@ -19,4 +19,14 @@ export class PrismaChattingMessagesRepository implements IChattingMessagesReposi
     });
     return message;
   }
+
+  findById(messageId: string, ctx?: TransactionContext) {
+    const db = getDb(ctx, this.prisma);
+    return db.chattingMessage.findUnique({
+      where: { id: messageId },
+      include: {
+        quotation: true,
+      },
+    });
+  }
 }

--- a/src/modules/chat/infra/prisma.chatting-messages-read.repository.ts
+++ b/src/modules/chat/infra/prisma.chatting-messages-read.repository.ts
@@ -1,0 +1,25 @@
+import { IChattingMessagesReadRepository } from '../interface/chatting-messages-read.repository.interface';
+import { PrismaService } from '@/shared/prisma/prisma.service';
+import { TransactionContext } from '@/shared/prisma/transaction-runner.interface';
+import { getDb } from '@/shared/prisma/get-db';
+
+export class PrismaChattingMessagesReadRepository implements IChattingMessagesReadRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async upsertRead(messageId: string, userId: string, ctx?: TransactionContext): Promise<void> {
+    const db = getDb(ctx, this.prisma);
+    await db.chatMessageRead.upsert({
+      where: {
+        messageId_userId: {
+          messageId,
+          userId,
+        },
+      },
+      update: {},
+      create: {
+        messageId,
+        userId,
+      },
+    });
+  }
+}

--- a/src/modules/chat/interface/chatting-messages-read.repository.interface.ts
+++ b/src/modules/chat/interface/chatting-messages-read.repository.interface.ts
@@ -1,0 +1,7 @@
+import { TransactionContext } from '@/shared/prisma/transaction-runner.interface';
+
+export interface IChattingMessagesReadRepository {
+  upsertRead(messageId: string, userId: string, ctx?: TransactionContext): Promise<void>;
+}
+
+export const CHATTING_MESSAGES_READ_REPOSITORY = 'IChattingMessagesReadRepository';

--- a/src/modules/chat/interface/chatting-messages.repository.interface.ts
+++ b/src/modules/chat/interface/chatting-messages.repository.interface.ts
@@ -1,7 +1,7 @@
 import { MessageType } from '@/shared/constant/values';
 import { TransactionContext } from '@/shared/prisma/transaction-runner.interface';
 import { ChattingMessageRecord } from '../types';
-
+import { ChattingMessageEntity } from '../types';
 export type CreateChattingMessageInput = {
   chattingRoomId: string;
   senderId: string;
@@ -12,6 +12,7 @@ export type CreateChattingMessageInput = {
 
 export interface IChattingMessagesRepository {
   create(input: CreateChattingMessageInput, ctx?: TransactionContext): Promise<ChattingMessageRecord>;
+  findById(messageId: string, ctx?: TransactionContext): Promise<ChattingMessageEntity | null>;
 }
 
 export const CHATTING_MESSAGES_REPOSITORY = 'IChattingMessagesRepository';

--- a/src/modules/chat/ws/dto/chat-read.dto.ts
+++ b/src/modules/chat/ws/dto/chat-read.dto.ts
@@ -1,0 +1,10 @@
+import { createZodDto } from '@anatine/zod-nestjs';
+import { z } from 'zod';
+
+export const chatReadBodySchema = z.object({
+  roomId: z.string().uuid(),
+  lastReadMessageId: z.string().uuid(),
+});
+
+export type ChatReadBody = z.infer<typeof chatReadBodySchema>;
+export class ChatReadBodyDto extends createZodDto(chatReadBodySchema) {}

--- a/src/modules/chat/ws/dto/send-message.dto.ts
+++ b/src/modules/chat/ws/dto/send-message.dto.ts
@@ -1,5 +1,4 @@
 import { MoveTypeSchema } from '@/shared/constant/enums.schema';
-import { createZodDto } from '@anatine/zod-nestjs';
 import { z } from 'zod';
 
 export const SEND_LIMITS = {

--- a/src/modules/chat/ws/ws.types.ts
+++ b/src/modules/chat/ws/ws.types.ts
@@ -1,5 +1,4 @@
 import type { AccessTokenPayload } from '@/shared/jwt/jwt.payload.schema';
-import type { MessageType } from '@/shared/constant/values';
 
 export type C2S = {
   'chat:join': (p: { roomId: string }) => void;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#103 

## #️⃣ 작업 내용
- WS 이벤트 수신 추가
  - @SubscribeMessage(WS_EVENTS.CHAT_READ) 핸들러에서 읽음 요청을 받도록 구현
  - chatReadBodySchema로 요청 바디 검증
  - 검증 실패 시 VALIDATION_FAILED 응답 반환
- 읽음 처리 서비스 로직 추가
  - ChatMessageWsService.readMessage(...) 구현
  - 소켓에서 인증 사용자(client.data.user) 추출
  - 메시지 ID(lastReadMessageId)로 메시지 조회
  - 메시지가 속한 채팅방 재조회 후 참여자 여부 검증
  - 현재 사용자와 메시지 조합으로 ChatMessageRead upsert 처리
  - 성공 시 { messageId, roomId } 반환
- 레포지토리 사용
  - 메시지 조회: IChattingMessagesRepository.findById(...)
  - 방 조회: IChattingRoomsRepository.findById(...)
  - 읽음 기록 저장: IChattingMessagesReadRepository.upsertRead(...) 호출
- 알림/브로드캐스트는 보류
  - 현재 PR에서는 상대방 유저에게 chat:read 이벤트를 전파하지 않음
  - 추후 공통 알림/WS 브로드캐스트 모듈 정리 시점에 추가 예정
  
## #️⃣ 변경 사항 체크리스트
- [x] WebSocket 이벤트 추가 (chat:read)
- [x] DTO/스키마 추가 및 검증
- [x] 서비스 레이어에서 레포지토리만 사용하도록 분리
- [x] 비참여자 접근 차단
- [ ] 상대방 실시간 전파 (추후 알림 리팩토링 시 추가)
- [ ] HTTP 조회 응답에 읽음 정보 노출 (추후 작업)