### PR TITLE
[FEAT] 웹소켓 기반 알림 시스템 구축 및 DI 설정 완료 #111

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { ChatModule } from './modules/chat/chat.module';
 import { QuotationModule } from './modules/quotations/quotation.module';
 import { WeatherModule } from './modules/weather/weather.module';
 import { ReviewModule } from './modules/reviews/review.module';
+import { NotificationModule } from './modules/notification/notification.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { ReviewModule } from './modules/reviews/review.module';
     QuotationModule,
     WeatherModule,
     ReviewModule,
+    NotificationModule,
   ],
   controllers: [],
   providers: [],

--- a/src/modules/chat/ws/ws.types.ts
+++ b/src/modules/chat/ws/ws.types.ts
@@ -1,4 +1,5 @@
 import type { AccessTokenPayload } from '@/shared/jwt/jwt.payload.schema';
+import { NotificationType } from '@/shared/constant/values';
 
 export type C2S = {
   'chat:join': (p: { roomId: string }) => void;
@@ -6,7 +7,6 @@ export type C2S = {
   'chat:read': (p: { roomId: string; lastReadIdx: number }) => void;
 };
 
-// Client to Server (서버 -> 클라이언트로 보내는 이벤트 시그니처)
 export type S2C = {
   'conn:ok': (p: { userId: string; role: 'CONSUMER' | 'DRIVER' }) => void;
   'error:event': (p: { code: string; message: string }) => void;
@@ -32,7 +32,27 @@ export type S2C = {
           tempId: string;
         };
   }) => void;
+  'notify:connected': (p: { userId: string; message: string }) => void;
+  'notify:new': (p: {
+    id: string;
+    receiverId: string;
+    senderId?: string | null;
+    content: string;
+    notificationType: NotificationType;
+    createdAt: string;
+    readAt?: string | null;
+    requestId?: string | null;
+    quotationId?: string | null;
+    chattingRoomId?: string | null;
+    reviewId?: string | null;
+  }) => void;
 };
+
+export const NOTI_EVENTS = {
+  CONNECTED: 'notify:connected',
+  NEW: 'notify:new',
+  PING: 'notify:ping',
+} as const;
 
 // Internal Server Event (서버 내부에서 사용하는 이벤트 시그니처)
 export type ISE = Record<string, never>;

--- a/src/modules/notification/infra/prisma-notification.repository.ts
+++ b/src/modules/notification/infra/prisma-notification.repository.ts
@@ -1,0 +1,16 @@
+import { PrismaService } from '@/shared/prisma/prisma.service';
+import { IPrismaNotificationRepository } from '../interface/notification.repository.interface';
+import { Injectable } from '@nestjs/common';
+import { CreateNotificationInput, NotificationEntity } from '../types';
+
+@Injectable()
+export class PrismaNotificationRepository implements IPrismaNotificationRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(payload: CreateNotificationInput): Promise<NotificationEntity> {
+    const notification = await this.prisma.notification.create({
+      data: payload,
+    });
+    return notification;
+  }
+}

--- a/src/modules/notification/interface/notification.repository.interface.ts
+++ b/src/modules/notification/interface/notification.repository.interface.ts
@@ -1,0 +1,8 @@
+import { CreateNotificationInput } from '../types';
+import { NotificationEntity } from '../types';
+
+export interface IPrismaNotificationRepository {
+  create(payload: CreateNotificationInput): Promise<NotificationEntity>;
+}
+
+export const NOTIFICATION_REPOSITORY = 'INotificationRepository';

--- a/src/modules/notification/notification.module.ts
+++ b/src/modules/notification/notification.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { NotificationService } from './notification.service';
+import { NotificationGateway } from './ws/notification.gateway';
+import { PrismaNotificationRepository } from './infra/prisma-notification.repository';
+import { PrismaService } from '@/shared/prisma/prisma.service';
+import { NOTIFICATION_REPOSITORY } from './interface/notification.repository.interface';
+import { PresenceService } from '@/modules/chat/ws/presence.service';
+import { JwtModule } from '@/shared/jwt/jwt.module';
+import { PrismaModule } from '@/shared/prisma/prisma.module';
+import { CookieModule } from '@/shared/utils/cookie.module';
+
+@Module({
+  imports: [JwtModule, CookieModule, PrismaModule],
+  providers: [
+    PrismaService,
+    { provide: NOTIFICATION_REPOSITORY, useClass: PrismaNotificationRepository },
+    NotificationService,
+    NotificationGateway,
+    PresenceService,
+  ],
+  exports: [NotificationService],
+})
+export class NotificationModule {}

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -1,0 +1,21 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  type IPrismaNotificationRepository,
+  NOTIFICATION_REPOSITORY,
+} from './interface/notification.repository.interface';
+import { CreateNotificationInput } from './types';
+import { NotificationGateway } from './ws/notification.gateway';
+
+@Injectable()
+export class NotificationService {
+  constructor(
+    @Inject(NOTIFICATION_REPOSITORY)
+    private readonly notificationRepository: IPrismaNotificationRepository,
+    private readonly gateway: NotificationGateway,
+  ) {}
+
+  async createNotification(payload: CreateNotificationInput) {
+    const notification = await this.notificationRepository.create(payload);
+    this.gateway.sendToUser(payload.receiverId, notification);
+  }
+}

--- a/src/modules/notification/types.ts
+++ b/src/modules/notification/types.ts
@@ -1,0 +1,40 @@
+import { NotificationType } from '@/shared/constant/values';
+
+export type NotificationEntity = {
+  id: string;
+  receiverId: string;
+  senderId?: string | null;
+  content: string;
+  notificationType: NotificationType;
+  createdAt: Date;
+  readAt: Date | null;
+  requestId?: string | null;
+  quotationId?: string | null;
+  chattingRoomId?: string | null;
+  reviewId?: string | null;
+};
+
+export type CreateNotificationInput = {
+  receiverId: string;
+  notificationType: NotificationType;
+  content: string;
+  senderId?: string;
+  requestId?: string;
+  quotationId?: string;
+  chattingRoomId?: string;
+  reviewId?: string;
+};
+
+export type SendNotificationPayload = {
+  id: string;
+  receiverId: string;
+  senderId?: string | null;
+  content: string;
+  notificationType: NotificationType;
+  createdAt: string;
+  readAt?: string | null;
+  requestId?: string | null;
+  quotationId?: string | null;
+  chattingRoomId?: string | null;
+  reviewId?: string | null;
+};

--- a/src/modules/notification/ws/notification.gateway.ts
+++ b/src/modules/notification/ws/notification.gateway.ts
@@ -1,0 +1,82 @@
+import { PresenceService } from '@/modules/chat/ws/presence.service';
+import { NOTI_EVENTS, type WsServer, type WsSocket } from '@/modules/chat/ws/ws.types';
+import { Logger } from '@nestjs/common';
+import {
+  ConnectedSocket,
+  MessageBody,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  OnGatewayInit,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
+import { NotificationEntity, SendNotificationPayload } from '../types';
+
+@WebSocketGateway({ cors: { origin: true, credentials: true } })
+export class NotificationGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
+  @WebSocketServer()
+  private server!: WsServer;
+  private readonly logger = new Logger(NotificationGateway.name);
+  constructor(private readonly presence: PresenceService) {}
+
+  afterInit(server: WsServer) {
+    this.server = server;
+    this.presence.bindServer(server);
+  }
+
+  async handleConnection(client: WsSocket) {
+    await this.presence.onConnect(client);
+
+    const user = client.data.user;
+    if (user) {
+      const room = this.getUserRoom(user.id);
+      if (!client.rooms.has(room)) {
+        await client.join(room);
+        this.logger.debug(`socket ${client.id} joined ${room}`);
+      }
+
+      client.emit(NOTI_EVENTS.CONNECTED, {
+        userId: user.id,
+        message: '알림 채널에 연결되었습니다.',
+      });
+    } else {
+      client.emit('error:event', {
+        code: 'AUTH_REQUIRED',
+        message: '알림을 받으려면 로그인해주세요.',
+      });
+      client.disconnect(true);
+    }
+  }
+
+  handleDisconnect(client: WsSocket) {
+    this.presence.onDisconnect(client);
+  }
+
+  sendToUser(userId: string, payload: NotificationEntity) {
+    const { createdAt, readAt } = payload;
+    const createdAtString = createdAt.toISOString();
+    const readAtString = readAt?.toISOString() ?? null;
+    const sendPayload: SendNotificationPayload = {
+      ...payload,
+      createdAt: createdAtString,
+      readAt: readAtString,
+    };
+    const room = this.getUserRoom(userId);
+    this.server.to(room).emit(NOTI_EVENTS.NEW, sendPayload);
+  }
+
+  @SubscribeMessage(NOTI_EVENTS.PING)
+  handlePing(@ConnectedSocket() client: WsSocket, @MessageBody() body: unknown) {
+    return {
+      ok: true,
+      now: new Date().toISOString(),
+      you: client.data.user ?? null,
+      echo: body ?? null,
+    };
+  }
+
+  private getUserRoom(userId: string) {
+    return `user:${userId}`;
+  }
+}

--- a/src/modules/quotations/quotation.service.ts
+++ b/src/modules/quotations/quotation.service.ts
@@ -1,11 +1,10 @@
-import { Inject, Injectable } from '@nestjs/common';
-import { QUOTATION_REPOSITORY } from './interface/quotation.repository.interface';
-import type { IQuotationRepository } from './interface/quotation.repository.interface';
-import { Prisma, QuotationStatus, RequestStatus } from '@prisma/client';
-import { QuotationSummaryDto } from './dto/quotation-list.dto';
-import { InternalServerException } from '@/shared/exceptions/internal-server-error.exception';
 import { BadRequestException, ForbiddenException, NotFoundException } from '@/shared/exceptions';
 import { PrismaTransactionRunner } from '@/shared/prisma/prisma-transaction-runner';
+import { Inject, Injectable } from '@nestjs/common';
+import { Prisma, QuotationStatus } from '@prisma/client';
+import { QuotationSummaryDto } from './dto/quotation-list.dto';
+import type { IQuotationRepository } from './interface/quotation.repository.interface';
+import { QUOTATION_REPOSITORY } from './interface/quotation.repository.interface';
 
 @Injectable()
 export class QuotationService {

--- a/src/shared/constant/values.ts
+++ b/src/shared/constant/values.ts
@@ -39,3 +39,17 @@ export type MessageType = (typeof MESSAGE_TYPES)[number];
 
 export const QUOTATION_STATUSES = ['PENDING', 'CONCLUDED', 'COMPLETED', 'REJECTED', 'EXPIRED', 'CANCELLED'] as const;
 export type QuotationStatus = (typeof QUOTATION_STATUSES)[number];
+
+export const NOTIFICATION_TYPES = [
+  'NEW_QUOTATION',
+  'QUOTATION_ACCEPTED',
+  'NEW_MESSAGE',
+  'REVIEW_RECEIVED',
+  'INVITE_RECEIVED',
+  'INVITE_CANCELLED',
+  'REQUEST_CONCLUDED',
+  'REQUEST_COMPLETED',
+  'REQUEST_EXPIRED',
+  'MOVE_DAY_REMINDER',
+] as const;
+export type NotificationType = (typeof NOTIFICATION_TYPES)[number];


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#111 

## #️⃣ 작업 내용
- NotificationModule 생성 (Service, Gateway, Repository, Type 정의 포함)
- NotificationService → DB 저장 + Gateway 알림 전송 로직 구현
- NotificationGateway → 실시간 알림 채널 구축 (notify:new, notify:connected, notify:ping)
- PresenceService DI 연동으로 사용자별 소켓 방(user:{id}) 관리
- ws.types.ts에 Notification 이벤트 타입(notify:new, notify:connected) 정의 추가
- 전체 DI 순환 의존성 및 경로 통일 (@/... 기반)

## 💡 사용 방법 요약 (개발자 참고)

### 1. 어디서든 NotificationService 주입
```
constructor(private readonly notificationService: NotificationService) {}
```
### 2. 알림 생성 + 전송 한 번에
```
await this.notificationService.createNotification({
  receiverId: 'uuid-of-target-user',
  senderId: currentUser.id,
  notificationType: NotificationType.NEW_QUOTATION,
  content: '새로운 견적이 도착했습니다.',
  quotationId,
});
```
→ 자동으로 DB 저장 후 해당 유저의 웹소켓 방(user:{receiverId})에 notify:new 이벤트 전송됨

### 3. 프론트에서 수신
```
socket.on('notify:new', (payload) => {
  // payload: { id, type, content, createdAt, ... }
  showToast(payload.content);
});
```