### PR TITLE
Feat/node cron 견적 자동 이행 로직추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "cookie-parser": "^1.4.7",
         "morgan": "^1.10.1",
         "ms": "^2.1.3",
+        "node-cron": "^4.2.1",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-kakao": "^1.0.1",
@@ -8704,6 +8705,15 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-emoji": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "cookie-parser": "^1.4.7",
     "morgan": "^1.10.1",
     "ms": "^2.1.3",
+    "node-cron": "^4.2.1",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-kakao": "^1.0.1",

--- a/src/modules/quotations/dto/quotation-status.dto.ts
+++ b/src/modules/quotations/dto/quotation-status.dto.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+import { QuotationStatus } from '@prisma/client';
+
+export const UpdateQuotationStatusSchema = z.object({
+  quotationId: z.string().uuid({ message: 'quotationId는 유효한 UUID여야 합니다.' }),
+
+  moveAt: z.string().datetime({ offset: true, message: 'moveAt은 ISO8601 형식의 날짜여야 합니다.' }),
+
+  status: z.nativeEnum(QuotationStatus).optional().default(QuotationStatus.COMPLETED),
+});
+
+export type UpdateQuotationStatusDto = z.infer<typeof UpdateQuotationStatusSchema>;

--- a/src/modules/quotations/infra/prisma-quotation.repository.ts
+++ b/src/modules/quotations/infra/prisma-quotation.repository.ts
@@ -76,4 +76,19 @@ export class PrismaQuotationRepository implements IQuotationRepository {
       },
     });
   }
+
+  async findUncompletedAfterNow() {
+    return this.prisma.quotation.findMany({
+      where: {
+        status: { notIn: [QuotationStatus.COMPLETED, QuotationStatus.CANCELLED] },
+        moveAt: { gt: new Date() },
+      },
+    });
+  }
+  async updateStatus(id: string, status: QuotationStatus): Promise<Quotation> {
+    return this.prisma.quotation.update({
+      where: { id },
+      data: { status },
+    });
+  }
 }

--- a/src/modules/quotations/infra/quotation.scheduler.ts
+++ b/src/modules/quotations/infra/quotation.scheduler.ts
@@ -1,0 +1,33 @@
+import cron from 'node-cron';
+import { IQuotationRepository } from '../interface/quotation.repository.interface';
+import { QuotationStatus } from '@prisma/client';
+
+/**
+ * moveAt 시간에 맞춰 quotation.status를 COMPLETED로 변경하는 스케줄 등록
+ */
+export function scheduleQuotationCompletionJob(
+  quotationId: string,
+  moveAt: Date,
+  quotationRepository: IQuotationRepository,
+  status: QuotationStatus = QuotationStatus.COMPLETED,
+) {
+  const cronTime = `${moveAt.getSeconds()} ${moveAt.getMinutes()} ${moveAt.getHours()} ${moveAt.getDate()} ${
+    moveAt.getMonth() + 1
+  } *`;
+
+  console.log(`🕒 quotation ${quotationId} 스케줄 등록됨: ${cronTime}`);
+
+  cron.schedule(
+    cronTime,
+    async () => {
+      const quotation = await quotationRepository.findById(quotationId);
+      if (quotation?.status === QuotationStatus.CONCLUDED) {
+        await quotationRepository.updateStatus(quotationId, QuotationStatus.COMPLETED);
+        console.log(`✅ quotation ${quotationId} -> COMPLETED 완료`);
+      } else {
+        console.log(`⏩ quotation ${quotationId} 상태가 ${quotation?.status} 이므로 건너뜀`);
+      }
+    },
+    { timezone: 'Asia/Seoul' },
+  );
+}

--- a/src/modules/quotations/interface/quotation.repository.interface.ts
+++ b/src/modules/quotations/interface/quotation.repository.interface.ts
@@ -31,6 +31,8 @@ export interface IQuotationRepository {
   acceptQuotation(id: string, ctx?: TransactionContext): Promise<Quotation>;
   rejectOtherQuotations(requestId: string, excludeQuotationId: string, ctx?: TransactionContext): Promise<void>;
   findById(id: string): Promise<QuotationWithRelationsPlusId | null>;
+  updateStatus(id: string, status: QuotationStatus): Promise<Quotation>;
+  findUncompletedAfterNow(): Promise<Quotation[]>;
 }
 
 export const QUOTATION_REPOSITORY = 'IQuotationRepository';

--- a/src/modules/quotations/interface/quotation.service.interface.ts
+++ b/src/modules/quotations/interface/quotation.service.interface.ts
@@ -1,6 +1,10 @@
 import { QuotationStatus } from '@prisma/client';
 import { QuotationSummaryDto } from '../dto/quotation-list.dto';
+import { UpdateQuotationStatusDto } from '../dto/quotation-status.dto';
 
 export interface IQuotationService {
   findDriverQuotationsByStatus(driverId: string, statuses?: QuotationStatus[]): Promise<QuotationSummaryDto[]>;
+  scheduleQuotationCompletion(
+    dto: UpdateQuotationStatusDto,
+  ): Promise<{ message: string; quotationId: string; scheduledAt?: Date }>;
 }

--- a/src/modules/quotations/quotation.controller.ts
+++ b/src/modules/quotations/quotation.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpCode, HttpStatus, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Query, UseGuards } from '@nestjs/common';
 import { QuotationService } from './quotation.service';
 import { AccessTokenGuard } from '../auth/guards/accessToken.guard';
 import { RolesGuard } from '../auth/guards/role.guard';
@@ -6,6 +6,9 @@ import { RequireRoles } from '../auth/decorators/roles.decorator';
 import { QuotationStatus } from '@prisma/client';
 import type { AccessTokenPayload } from '@/shared/jwt/jwt.payload.schema';
 import { AuthUser } from '../auth/decorators/auth-user.decorator';
+import { ZodValidationPipe } from '@/shared/pipes/zod-validation.pipe';
+import { UpdateQuotationStatusSchema } from './dto/quotation-status.dto';
+import type { UpdateQuotationStatusDto } from './dto/quotation-status.dto';
 
 @Controller('quotations')
 export class QuotationController {
@@ -31,5 +34,12 @@ export class QuotationController {
       success: true,
       data: result,
     };
+  }
+  @Post('complete/schedule')
+  async scheduleCompletion(
+    @Body(new ZodValidationPipe(UpdateQuotationStatusSchema))
+    dto: UpdateQuotationStatusDto,
+  ) {
+    return this.quotationService.scheduleQuotationCompletion(dto);
   }
 }

--- a/test/http-test/nam.http
+++ b/test/http-test/nam.http
@@ -173,9 +173,9 @@ GET {{host}}/weather/forecast?city=Seoul&days=5
 Content-Type: application/json
 
 ### 견적 수락 테스트
-POST {{host}}/quotations/be7186a1-ac7d-4c18-8939-2d7a63e16d14/accept
+POST {{host}}/quotations/56c8bd2b-fe44-4db8-b44a-beb67ea6e571/accept
 Content-Type: application/json
-Cookie: __Host-access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI0OWRkODg1ZC1iYjVjLTQ5ZTQtODk5ZC04NTkwOGNjM2EzOTgiLCJqdGkiOiJlYTFiMTNiNC0wNGFiLTQ0OTQtYWVkNC03MjcyMWJiYzNhMzEiLCJyb2xlIjoiQ09OU1VNRVIiLCJpYXQiOjE3NjE5OTk3NDgsImV4cCI6MTc2MjAwMDY0OCwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo0MDAwIn0.4rXvu8yd7YcseTK0H4RjX8xO7xSFA-DjLXwVL7_mrks
+Cookie: __Host-access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI0OWI5MmVmOS1lZmMxLTQ1ZWUtOWU2Mi0zYjM5YzIxNzIyNDEiLCJqdGkiOiJiZTgxNDc0ZC1jNTQzLTRhY2YtYTIwNi1lYWY2MWY5NDc3NGEiLCJyb2xlIjoiQ09OU1VNRVIiLCJpYXQiOjE3NjIyMzM0OTIsImV4cCI6MTc2MjIzNDM5MiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo0MDAwIn0.97iFWxJGMmx0TBpPYe6X-g9SwRx4aQejXY4RH8SSq98
 
 
 
@@ -184,8 +184,8 @@ POST {{host}}/auth/signin
 Content-Type: application/json
 
 {
-  "email": "nowter@test.com",
-  "password": "nowter123",
+  "email": "gotest8@test.com",
+  "password": "12345678",
   "role": "CONSUMER"
 }
 
@@ -221,3 +221,23 @@ Content-Type: application/json
 GET {{host}}/reviews/drivers/c09493c9-fa43-42a2-8119-c400450b91a3/rating
 Content-Type: application/json
 Cookie: __Host-access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI0OWRkODg1ZC1iYjVjLTQ5ZTQtODk5ZC04NTkwOGNjM2EzOTgiLCJqdGkiOiI0NDMxNTMxNC1mNjU3LTQ3MGMtYTA4NC03MTQ2ZTQwZDA4YTUiLCJyb2xlIjoiQ09OU1VNRVIiLCJpYXQiOjE3NjIwMDA3NjAsImV4cCI6MTc2MjAwMTY2MCwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo0MDAwIn0.Nc3HP0z-shZNHFSqGOda-RU9zrwb68YMk5VPfocVmd4
+
+
+
+### 🧾 견적 자동완료 스케줄 등록 테스트
+POST {{host}}/quotations/complete/schedule
+Content-Type: application/json
+
+{
+  "quotationId": "192ebb5b-88b9-4bd8-a8a1-62dbd8249900",
+  "moveAt": "2025-10-30T00:00:00.000Z"
+}
+
+### 3분 뒤 자동 완료 테스트
+POST {{host}}/quotations/complete/schedule
+Content-Type: application/json
+
+{
+  "quotationId": "4957faf1-40f1-4be8-833c-9bb8deb28b85",
+  "moveAt": "2025-11-04T13:48:00+09:00"
+}


### PR DESCRIPTION
## 개요
- `node-cron`을 활용한 **이사 예약 자동 완료 시스템** 구현  
- `moveAt` 시간을 기준으로 스케줄이 등록되며,  
  고객이 **채팅방 내에서 계약서를 확인 후 확정 버튼을 누르는 순간** 자동으로 스케줄이 설정됩니다.  
- 예약된 시간이 지나면 해당 견적(`Quotation`)의 상태가 **자동으로 `COMPLETED`** 로 변경됩니다.

## 테스트 결과
- 예약 등록 및 자동 완료 동작 모두 **정상적으로 작동 확인 (성공적)** 
