### PR TITLE
[FEAT] 알림 조회 API 구현

### DIFF
--- a/src/modules/notification/infra/prisma-notification.repository.ts
+++ b/src/modules/notification/infra/prisma-notification.repository.ts
@@ -1,5 +1,5 @@
 import { PrismaService } from '@/shared/prisma/prisma.service';
-import { IPrismaNotificationRepository } from '../interface/notification.repository.interface';
+import { FindNotificationsArgs, IPrismaNotificationRepository } from '../interface/notification.repository.interface';
 import { Injectable } from '@nestjs/common';
 import { CreateNotificationInput, NotificationEntity } from '../types';
 
@@ -12,5 +12,24 @@ export class PrismaNotificationRepository implements IPrismaNotificationReposito
       data: payload,
     });
     return notification;
+  }
+
+  async findManyByUser(args: FindNotificationsArgs): Promise<NotificationEntity[]> {
+    const { userId, take, cursor, onlyUnread } = args;
+
+    return this.prisma.notification.findMany({
+      where: {
+        receiverId: userId,
+        ...(onlyUnread && { readAt: null }),
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      ...(cursor && {
+        cursor: { id: cursor },
+        skip: 1,
+      }),
+      take,
+    });
   }
 }

--- a/src/modules/notification/interface/dto/get-notifications.dto.ts
+++ b/src/modules/notification/interface/dto/get-notifications.dto.ts
@@ -1,0 +1,11 @@
+import { createZodDto } from '@anatine/zod-nestjs';
+import { z } from 'zod';
+
+export const getNotificationsQuerySchema = z.object({
+  cursor: z.string().uuid().optional(),
+  limit: z.coerce.number().int().min(1).max(30).default(30),
+});
+
+export type GetNotificationsQuery = z.infer<typeof getNotificationsQuerySchema>;
+
+export class GetNotificationsQueryDto extends createZodDto(getNotificationsQuerySchema) {}

--- a/src/modules/notification/interface/notification.repository.interface.ts
+++ b/src/modules/notification/interface/notification.repository.interface.ts
@@ -1,8 +1,15 @@
-import { CreateNotificationInput } from '../types';
-import { NotificationEntity } from '../types';
+import { CreateNotificationInput, NotificationEntity } from '../types';
+
+export interface FindNotificationsArgs {
+  userId: string;
+  take: number;
+  cursor?: string;
+  onlyUnread?: boolean;
+}
 
 export interface IPrismaNotificationRepository {
   create(payload: CreateNotificationInput): Promise<NotificationEntity>;
+  findManyByUser(args: FindNotificationsArgs): Promise<NotificationEntity[]>;
 }
 
 export const NOTIFICATION_REPOSITORY = 'INotificationRepository';

--- a/src/modules/notification/interface/notification.service.interface.ts
+++ b/src/modules/notification/interface/notification.service.interface.ts
@@ -1,0 +1,15 @@
+import { CreateNotificationInput, NotificationEntity } from '../types';
+import { GetNotificationsQuery } from './dto/get-notifications.dto';
+
+export interface GetNotificationsResult {
+  items: NotificationEntity[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}
+
+export interface INotificationService {
+  createNotification(payload: CreateNotificationInput): Promise<void>;
+  getNotifications(userId: string, input: GetNotificationsQuery): Promise<GetNotificationsResult>;
+}
+
+export const NOTIFICATION_SERVICE = 'INotificationService';

--- a/src/modules/notification/notification.controller.ts
+++ b/src/modules/notification/notification.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Inject, Query, Get } from '@nestjs/common';
+import { NOTIFICATION_SERVICE, type INotificationService } from './interface/notification.service.interface';
+import { type AccessTokenPayload } from '@/shared/jwt/jwt.payload.schema';
+import { GetNotificationsQueryDto } from './interface/dto/get-notifications.dto';
+import { AuthUser } from '../auth/decorators/auth-user.decorator';
+import { ZodValidationPipe } from '@/shared/pipes/zod-validation.pipe';
+import { getNotificationsQuerySchema } from './interface/dto/get-notifications.dto';
+import { AccessTokenGuard } from '../auth/guards/accessToken.guard';
+import { UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+@Controller('Notifications')
+export class NotificationController {
+  constructor(
+    @Inject(NOTIFICATION_SERVICE)
+    private readonly notificationService: INotificationService,
+  ) {}
+
+  @Get()
+  @UseGuards(AccessTokenGuard)
+  @ApiOperation({ summary: '알림 조회' })
+  @ApiResponse({ status: 200, description: '알림 조회 성공' })
+  async getNotifications(
+    @AuthUser() user: AccessTokenPayload,
+    @Query(new ZodValidationPipe(getNotificationsQuerySchema)) query: GetNotificationsQueryDto,
+  ) {
+    return this.notificationService.getNotifications(user.sub, query);
+  }
+}

--- a/src/modules/notification/notification.module.ts
+++ b/src/modules/notification/notification.module.ts
@@ -1,13 +1,15 @@
-import { Module } from '@nestjs/common';
-import { NotificationService } from './notification.service';
-import { NotificationGateway } from './ws/notification.gateway';
-import { PrismaNotificationRepository } from './infra/prisma-notification.repository';
-import { PrismaService } from '@/shared/prisma/prisma.service';
-import { NOTIFICATION_REPOSITORY } from './interface/notification.repository.interface';
 import { PresenceService } from '@/modules/chat/ws/presence.service';
 import { JwtModule } from '@/shared/jwt/jwt.module';
 import { PrismaModule } from '@/shared/prisma/prisma.module';
+import { PrismaService } from '@/shared/prisma/prisma.service';
 import { CookieModule } from '@/shared/utils/cookie.module';
+import { Module } from '@nestjs/common';
+import { PrismaUserRepository } from '../users/infra/prisma-user.repository';
+import { USER_REPOSITORY } from '../users/interface/users.repository.interface';
+import { PrismaNotificationRepository } from './infra/prisma-notification.repository';
+import { NOTIFICATION_REPOSITORY } from './interface/notification.repository.interface';
+import { NotificationService } from './notification.service';
+import { NotificationGateway } from './ws/notification.gateway';
 
 @Module({
   imports: [JwtModule, CookieModule, PrismaModule],
@@ -17,6 +19,7 @@ import { CookieModule } from '@/shared/utils/cookie.module';
     NotificationService,
     NotificationGateway,
     PresenceService,
+    { provide: USER_REPOSITORY, useClass: PrismaUserRepository },
   ],
   exports: [NotificationService],
 })

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -1,14 +1,20 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import type { IUserRepository } from '../users/interface/users.repository.interface';
+import { USER_REPOSITORY } from '../users/interface/users.repository.interface';
+import { GetNotificationsQuery } from './interface/dto/get-notifications.dto';
 import {
   type IPrismaNotificationRepository,
   NOTIFICATION_REPOSITORY,
 } from './interface/notification.repository.interface';
+import { GetNotificationsResult, INotificationService } from './interface/notification.service.interface';
 import { CreateNotificationInput } from './types';
 import { NotificationGateway } from './ws/notification.gateway';
 
 @Injectable()
-export class NotificationService {
+export class NotificationService implements INotificationService {
   constructor(
+    @Inject(USER_REPOSITORY)
+    private readonly userRepository: IUserRepository,
     @Inject(NOTIFICATION_REPOSITORY)
     private readonly notificationRepository: IPrismaNotificationRepository,
     private readonly gateway: NotificationGateway,
@@ -17,5 +23,31 @@ export class NotificationService {
   async createNotification(payload: CreateNotificationInput) {
     const notification = await this.notificationRepository.create(payload);
     this.gateway.sendToUser(payload.receiverId, notification);
+  }
+
+  async getNotifications(userId: string, input: GetNotificationsQuery): Promise<GetNotificationsResult> {
+    const existingUser = await this.userRepository.findById(userId);
+    if (!existingUser) {
+      throw new NotFoundException('User not found');
+    }
+    const { limit, cursor } = input;
+    const take = Number(limit) + 1;
+
+    const notifications = await this.notificationRepository.findManyByUser({
+      userId,
+      take,
+      cursor,
+      onlyUnread: true,
+    });
+
+    const hasNext = notifications.length === take;
+    const items = hasNext ? notifications.slice(0, Number(limit)) : notifications;
+    const nextCursor = hasNext && items.length > 0 ? items[items.length - 1].id : null;
+
+    return {
+      items,
+      nextCursor,
+      hasNext,
+    };
   }
 }

--- a/test/http-test/notification.http
+++ b/test/http-test/notification.http
@@ -1,0 +1,3 @@
+###  알림 목록 조회 (읽지 않은 것만, 최신순)
+GET http://localhost:4000/notifications?limit=5
+Cookie: access_token=YOUR_TEST_ACCESS_TOKEN_HERE


### PR DESCRIPTION
#️⃣ 연관된 이슈
- (: #135)

#️⃣ 작업 내용
- 읽지 않은 알림만 조회하는 알림 조회 API 추가
  - `GET /notifications`
  - `AccessTokenGuard` 적용으로 로그인 사용자만 조회 가능
- `INotificationService`에 알림 조회 메서드 정의
  - `getNotifications(userId: string, input: GetNotificationsQuery): Promise<GetNotificationsResult>`
  - 응답 형태:
    - `items`: `NotificationEntity[]`
    - `nextCursor`: string \| null
    - `hasNext`: boolean
- 서비스 구현
  - `NotificationService.getNotifications`에서 커서 기반 페이징 처리
    - `limit + 1`개 조회 후 `hasNext` / `nextCursor` 계산
    - `onlyUnread: true` 옵션으로 읽지 않은 알림만 조회
- 레포지토리 인터페이스 및 구현 추가
  - `FindNotificationsArgs` 정의 (`userId`, `take`, `cursor?`, `onlyUnread?`)
  - `IPrismaNotificationRepository.findManyByUser` 추가
  - `PrismaNotificationRepository.findManyByUser`에서 Prisma `findMany`로 구현
    - `receiverId` 기준 필터
    - `readAt: null` 조건으로 미읽음 필터링
    - `createdAt DESC` 정렬
    - `cursor` + `skip: 1`로 커서 페이징 적용
- 쿼리 DTO 및 검증 추가
  - `GetNotificationsQueryDto` / `getNotificationsQuerySchema` 정의
    - `cursor?: string (uuid)`
    - `limit: number (1~30, 기본값 30)`
  - `ZodValidationPipe(getNotificationsQuerySchema)`를 통해 쿼리 검증

#️⃣ 테스트 결과

| 시나리오                  | 입력                                               | 기대 결과                                                        | 실제 결과 |
|---------------------------|----------------------------------------------------|------------------------------------------------------------------|-----------|
| ✅ 정상 조회              | 로그인 사용자, `GET /notifications?limit=5`       | 최신순으로 읽지 않은 알림 최대 5개 반환, `nextCursor` 적절히 설정 | ✅        |
| ✅ 2페이지 조회 (커서)    | `GET /notifications?limit=5&cursor={prevLastId}`  | cursor 이후의 읽지 않은 알림 최대 5개, 다음 페이지가 있으면 `hasNext=true` | ✅        |
| ✅ 미읽음 없음            | 읽지 않은 알림이 없는 상태                        | `items`는 빈 배열, `hasNext=false`, `nextCursor=null`           | ✅        |
| ❌ 비로그인 상태          | 쿠키/인증 헤더 없음                               | `401 Unauthorized` 반환                                          | ✅        |

#️⃣ 변경 사항 체크리스트
- [x] Swagger 문서(`@ApiOperation`, `@ApiResponse`)가 최신 상태입니다.
- [x] 관련 문서(노션, 위키 등)를 업데이트했습니다.